### PR TITLE
Implement Drag and Drop For ResumeBuilder form on frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@heroicons/react": "^2.2.0",
@@ -2237,6 +2240,59 @@
       },
       "peerDependencies": {
         "postcss-selector-parser": "^6.0.10"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "homepage": "/resume-builder",
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@heroicons/react": "^2.2.0",

--- a/src/Components/DraggableSection.js
+++ b/src/Components/DraggableSection.js
@@ -16,17 +16,18 @@ const DraggableSection = ({ id, children }) => {
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.5 : 1,
-    touchAction: 'none'
   };
 
   return (
-    <div ref={setNodeRef} style={style} {...attributes} {...listeners} >
-      <div className="cursor-move bg-gray-50 dark:bg-gray-800 p-2 mb-2 rounded flex items-center justify-center">
+    <div ref={setNodeRef} {...attributes} className='bg-gradient-to-r from-blue-50 to-white dark:from-gray-800 dark:to-gray-800 p-6 pt-1 rounded-xl outline outline-slate-300 shadow-sm mb-8' style={{touchAction: 'none'}}>
+      <div className="cursor-move dark:bg-gray-800 p-1 mb-1 rounded flex items-center justify-center" {...listeners}>
         <svg className="w-6 h-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 8h16M4 16h16" />
         </svg>
       </div>
-      {children}
+      <div style={style}>
+        {children}
+      </div>
     </div>
   );
 };

--- a/src/Components/DraggableSection.js
+++ b/src/Components/DraggableSection.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+
+const DraggableSection = ({ id, children }) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    touchAction: 'none'
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners} >
+      <div className="cursor-move bg-gray-50 dark:bg-gray-800 p-2 mb-2 rounded flex items-center justify-center">
+        <svg className="w-6 h-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 8h16M4 16h16" />
+        </svg>
+      </div>
+      {children}
+    </div>
+  );
+};
+
+export default DraggableSection;

--- a/src/Components/ResumeBuilder.js
+++ b/src/Components/ResumeBuilder.js
@@ -500,1165 +500,1166 @@ const ResumeBuilder = ({
           </div>
         </section>
 
-        {/* Education Section */}
         <SortableContext
           items={sectionOrder}
           strategy={verticalListSortingStrategy}>
           {sectionOrder.map((sectionId) => (
             <DraggableSection key={sectionId} id={sectionId}>
-              {sectionId === "education" && (
-                <section className="mb-8">
-                  <div className="flex items-center justify-between mb-4">
-                    <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
-                      <span className="mr-2"></span> Education
-                    </h2>
-                    <button
-                      type="button"
-                      onClick={() => addEntry("education")}
-                      className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
-                      disabled={isSubmitted}
-                    >
-                      <PlusIcon className="w-5 h-5 mr-1" />
-                      Add Education
-                    </button>
-                  </div>
-
-                  {(resumeData.education || []).map((education, index) => (
-                    <div key={index} className={sectionCardClasses}>
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                            Degree/Certificate*
-                          </label>
-                          <input
-                            type="text"
-                            placeholder="e.g. Bachelor of Technology"
-                            className={inputClasses}
-                            value={education.degree}
-                            onChange={(e) =>
-                              handleInputChange(
-                                "education",
-                                index,
-                                "degree",
-                                e.target.value
-                              )
-                            }
-                            required
-                            disabled={isSubmitted}
-                          />
-                        </div>
-
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                            Institute/Board*
-                          </label>
-                          <input
-                            type="text"
-                            placeholder="e.g. University of XYZ"
-                            className={inputClasses}
-                            value={education.institute}
-                            onChange={(e) =>
-                              handleInputChange(
-                                "education",
-                                index,
-                                "institute",
-                                e.target.value
-                              )
-                            }
-                            required
-                            disabled={isSubmitted}
-                          />
-                        </div>
-
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                            CGPA/Percentage*
-                          </label>
-                          <input
-                            type="text"
-                            placeholder="e.g. 8.5 CGPA or 85\% (use \% for percentage or view instructions)"
-                            className={inputClasses}
-                            value={education.cgpa}
-                            onChange={(e) =>
-                              handleInputChange(
-                                "education",
-                                index,
-                                "cgpa",
-                                e.target.value
-                              )
-                            }
-                            required
-                            disabled={isSubmitted}
-                          />
-                        </div>
-
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                            Year*
-                          </label>
-                          <input
-                            type="text"
-                            placeholder="e.g. 2020-2024"
-                            className={inputClasses}
-                            value={education.year}
-                            onChange={(e) =>
-                              handleInputChange(
-                                "education",
-                                index,
-                                "year",
-                                e.target.value
-                              )
-                            }
-                            required
-                            disabled={isSubmitted}
-                          />
-                        </div>
-                      </div>
-                      <div className="flex justify-end">
+            <div className="section-content">
+                {sectionId === "education" && (
+                    <section className="">
+                    <div className="flex items-center justify-between mb-4">
+                        <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
+                        <span className="mr-2"></span> Education
+                        </h2>
                         <button
-                          type="button"
-                          onClick={() => {
-                            setDeleteTarget({ section: "education", index });
-                            setIsModalOpen(true);
-                          }}
-                          className=" text-red-500 hover:text-red-700 transition"
-                          disabled={isSubmitted}
-                          title="Delete this education entry"
+                        type="button"
+                        onClick={() => addEntry("education")}
+                        className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
+                        disabled={isSubmitted}
                         >
-                          <TrashIcon className="w-5 h-5" />
+                        <PlusIcon className="w-5 h-5 mr-1" />
+                        Add Education
                         </button>
-                      </div>
                     </div>
-                  ))}
-                </section>
-              )}
-              {sectionId === "experience" && (
-                <section className="mb-8">
-                  <div className="flex items-center justify-between mb-4">
-                    <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
-                      <span className="mr-2"></span> Experience
-                    </h2>
-                    <button
-                      type="button"
-                      onClick={() => addEntry("experience")}
-                      className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
-                      disabled={isSubmitted}
-                    >
-                      <PlusIcon className="w-5 h-5 mr-1" />
-                      Add Experience
-                    </button>
-                  </div>
 
-                  {(resumeData.experience || []).map((experience, index) => (
-                    <div key={index} className={sectionCardClasses}>
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                            Company*
-                          </label>
-                          <input
-                            type="text"
-                            placeholder="Company name"
-                            className={inputClasses}
-                            value={experience.company}
-                            onChange={(e) =>
-                              handleInputChange(
-                                "experience",
-                                index,
-                                "company",
-                                e.target.value
-                              )
-                            }
-                            required
-                            disabled={isSubmitted}
-                          />
-                        </div>
-
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                            Location
-                          </label>
-                          <input
-                            type="text"
-                            placeholder="e.g. Remote, Bangalore, etc."
-                            className={inputClasses}
-                            value={experience.location}
-                            onChange={(e) =>
-                              handleInputChange(
-                                "experience",
-                                index,
-                                "location",
-                                e.target.value
-                              )
-                            }
-                            disabled={isSubmitted}
-                            required
-                          />
-                        </div>
-
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                            Role*
-                          </label>
-                          <input
-                            type="text"
-                            placeholder="Your position"
-                            className={inputClasses}
-                            value={experience.role}
-                            onChange={(e) =>
-                              handleInputChange(
-                                "experience",
-                                index,
-                                "role",
-                                e.target.value
-                              )
-                            }
-                            required
-                            disabled={isSubmitted}
-                          />
-                        </div>
-
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                            Timeline*
-                          </label>
-                          <input
-                            type="text"
-                            placeholder="e.g. June 2022 - Present"
-                            className={inputClasses}
-                            value={experience.timeline}
-                            onChange={(e) =>
-                              handleInputChange(
-                                "experience",
-                                index,
-                                "timeline",
-                                e.target.value
-                              )
-                            }
-                            required
-                            disabled={isSubmitted}
-                          />
-                        </div>
-                      </div>
-
-                      <div className="mt-4">
-                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                          Work Done
-                        </label>
-                        {experience.workDone &&
-                          (experience.workDone || []).map((task, taskIndex) => (
-                            <div
-                              key={taskIndex}
-                              className="flex items-center gap-2 mb-2"
-                            >
-                              <span className="text-gray-500 dark:text-gray-400">
-                                •
-                              </span>
-                              <input
-                                type="text"
-                                placeholder={`Describe your work (${
-                                  taskIndex + 1
-                                })`}
-                                className={`${inputClasses} flex-1`}
-                                value={task}
-                                onChange={(e) => {
-                                  const updatedData = { ...resumeData };
-                                  updatedData.experience[index].workDone[
-                                    taskIndex
-                                  ] = e.target.value;
-                                  setResumeData(updatedData);
-                                }}
-                                disabled={isSubmitted}
-                              />
-                              <button
-                                type="button"
-                                onClick={() => {
-                                  const updatedData = { ...resumeData };
-                                  updatedData.experience[index].workDone.splice(
-                                    taskIndex,
-                                    1
-                                  );
-                                  setResumeData(updatedData);
-                                }}
-                                className="text-red-500 hover:text-red-700 p-2 rounded-full hover:bg-red-50 dark:hover:bg-gray-700 transition"
-                                title="Delete this task"
-                                disabled={isSubmitted}
-                              >
-                                <TrashIcon className="w-4 h-4" />
-                              </button>
-                            </div>
-                          ))}
-                        <button
-                          type="button"
-                          onClick={() => addWorkDone("experience", index)}
-                          className={`${buttonClasses} mt-2 bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 text-sm`}
-                          disabled={isSubmitted}
-                        >
-                          + Add Work Description
-                        </button>
-                      </div>
-
-                      <div className="flex justify-end">
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setDeleteTarget({ section: "experience", index });
-                            setIsModalOpen(true);
-                          }}
-                          className=" text-red-500 hover:text-red-700 transition"
-                          disabled={isSubmitted}
-                          title="Delete this experience entry"
-                        >
-                          <TrashIcon className="w-5 h-5" />
-                        </button>
-                      </div>
-                    </div>
-                  ))}
-                </section>
-              )}
-              {sectionId === "projects" && (
-                <section className="mb-8">
-                  <div className="flex items-center justify-between mb-4">
-                    <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
-                      <span className="mr-2"></span> Projects
-                    </h2>
-                    <button
-                      type="button"
-                      onClick={() => addEntry("projects")}
-                      className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
-                      disabled={isSubmitted}
-                    >
-                      <PlusIcon className="w-5 h-5 mr-1" />
-                      Add Project
-                    </button>
-                  </div>
-
-                  {(resumeData.projects || []).map((project, index) => (
-                    <div key={index} className={sectionCardClasses}>
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                            Project Name*
-                          </label>
-                          <input
-                            type="text"
-                            placeholder="Project title"
-                            className={inputClasses}
-                            value={project.name}
-                            onChange={(e) =>
-                              handleInputChange(
-                                "projects",
-                                index,
-                                "name",
-                                e.target.value
-                              )
-                            }
-                            required
-                            disabled={isSubmitted}
-                          />
-                        </div>
-
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                            Project Type
-                          </label>
-                          <input
-                            type="text"
-                            placeholder="e.g. Web App, Research, etc."
-                            className={inputClasses}
-                            value={project.type}
-                            onChange={(e) =>
-                              handleInputChange(
-                                "projects",
-                                index,
-                                "type",
-                                e.target.value
-                              )
-                            }
-                            disabled={isSubmitted}
-                          />
-                        </div>
-
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                            Timeline
-                          </label>
-                          <input
-                            type="text"
-                            placeholder="e.g. Jan 2023 - May 2023"
-                            className={inputClasses}
-                            value={project.timeline}
-                            onChange={(e) =>
-                              handleInputChange(
-                                "projects",
-                                index,
-                                "timeline",
-                                e.target.value
-                              )
-                            }
-                            disabled={isSubmitted}
-                          />
-                        </div>
-
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                            GitHub Link
-                          </label>
-                          <input
-                            type="url"
-                            placeholder="Project repository URL"
-                            className={inputClasses}
-                            value={project.githubLink}
-                            onChange={(e) =>
-                              handleInputChange(
-                                "projects",
-                                index,
-                                "githubLink",
-                                e.target.value
-                              )
-                            }
-                            disabled={isSubmitted}
-                          />
-                        </div>
-                      </div>
-
-                      <div className="mt-4">
-                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                          Project Details
-                        </label>
-                        {project.workDone &&
-                          (project.workDone || []).map((task, taskIndex) => (
-                            <div
-                              key={taskIndex}
-                              className="flex items-center gap-2 mb-2"
-                            >
-                              <span className="text-gray-500 dark:text-gray-400">
-                                •
-                              </span>
-                              <input
-                                type="text"
-                                placeholder={`Project detail (${
-                                  taskIndex + 1
-                                })`}
-                                className={`${inputClasses} flex-1`}
-                                value={task}
-                                onChange={(e) => {
-                                  const updatedData = { ...resumeData };
-                                  updatedData.projects[index].workDone[
-                                    taskIndex
-                                  ] = e.target.value;
-                                  setResumeData(updatedData);
-                                }}
-                                disabled={isSubmitted}
-                              />
-                              <button
-                                type="button"
-                                onClick={() => {
-                                  const updatedData = { ...resumeData };
-                                  updatedData.projects[index].workDone.splice(
-                                    taskIndex,
-                                    1
-                                  );
-                                  setResumeData(updatedData);
-                                }}
-                                className="text-red-500 hover:text-red-700 p-2 rounded-full hover:bg-red-50 dark:hover:bg-gray-700 transition"
-                                title="Delete this detail"
-                                disabled={isSubmitted}
-                              >
-                                <TrashIcon className="w-4 h-4" />
-                              </button>
-                            </div>
-                          ))}
-                        <button
-                          type="button"
-                          onClick={() => {
-                            const updatedData = { ...resumeData };
-
-                            if (!updatedData.projects) {
-                              updatedData.projects = [];
-                            }
-                            if (!updatedData.projects[index]) {
-                              updatedData.projects[index] = {};
-                            }
-
-                            if (
-                              !Array.isArray(
-                                updatedData.projects[index].workDone
-                              )
-                            ) {
-                              updatedData.projects[index].workDone = [];
-                            }
-
-                            updatedData.projects[index].workDone.push("");
-                            setResumeData(updatedData);
-                          }}
-                          className={`${buttonClasses} mt-2 bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 text-sm`}
-                          disabled={isSubmitted}
-                        >
-                          + Add Project Detail
-                        </button>
-                      </div>
-                      <div className="flex justify-end">
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setDeleteTarget({ section: "projects", index });
-                            setIsModalOpen(true);
-                          }}
-                          className=" text-red-500 hover:text-red-700 transition"
-                          disabled={isSubmitted}
-                          title="Delete this project"
-                        >
-                          <TrashIcon className="w-5 h-5" />
-                        </button>
-                      </div>
-                    </div>
-                  ))}
-                </section>
-              )}
-              {sectionId === "skills" && (
-                <section className="mb-8">
-                  <div className="flex items-center justify-between mb-4">
-                    <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
-                      <span className="mr-2"></span> Technical Skills
-                    </h2>
-                    <button
-                      type="button"
-                      onClick={() => addEntry("technicalSkills")}
-                      className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
-                      disabled={isSubmitted}
-                    >
-                      <PlusIcon className="w-5 h-5 mr-1" />
-                      Add Skill
-                    </button>
-                  </div>
-
-                  {(resumeData.technicalSkills || []).map((skill, index) => (
-                    <div key={index} className={sectionCardClasses}>
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                            Category*
-                          </label>
-                          <input
-                            type="text"
-                            placeholder="e.g. Programming Languages, Tools, etc."
-                            className={inputClasses}
-                            value={skill.category}
-                            onChange={(e) =>
-                              handleInputChange(
-                                "technicalSkills",
-                                index,
-                                "category",
-                                e.target.value
-                              )
-                            }
-                            required
-                            disabled={isSubmitted}
-                          />
-                        </div>
-
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                            Skills*
-                          </label>
-                          <input
-                            type="text"
-                            placeholder="Comma separated list (e.g. Java, Python, C++)"
-                            className={inputClasses}
-                            value={skill.skills}
-                            onChange={(e) =>
-                              handleInputChange(
-                                "technicalSkills",
-                                index,
-                                "skills",
-                                e.target.value
-                              )
-                            }
-                            required
-                            disabled={isSubmitted}
-                          />
-                        </div>
-                      </div>
-                      <div className="flex justify-end pt-2">
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setDeleteTarget({
-                              section: "technicalSkills",
-                              index,
-                            });
-                            setIsModalOpen(true);
-                          }}
-                          className=" text-red-500 hover:text-red-700 transition"
-                          disabled={isSubmitted}
-                          title="Delete this skill category"
-                        >
-                          <TrashIcon className="w-5 h-5" />
-                        </button>
-                      </div>
-                    </div>
-                  ))}
-                </section>
-              )}
-              {sectionId === "courses" && (
-                <section className="mb-8">
-                  <div className="flex items-center justify-between mb-4">
-                    <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
-                      <span className="mr-2"></span> Key Courses Taken
-                    </h2>
-                    <button
-                      type="button"
-                      onClick={() => addEntry("courses")}
-                      className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
-                      disabled={isSubmitted}
-                    >
-                      <PlusIcon className="w-5 h-5 mr-1" />
-                      Add Course
-                    </button>
-                  </div>
-
-                  {(resumeData.courses || []).map((course, index) => (
-                    <div key={index} className={sectionCardClasses}>
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                            Category
-                          </label>
-                          <input
-                            type="text"
-                            placeholder="e.g. Core, Electives, etc."
-                            className={inputClasses}
-                            value={course.category}
-                            onChange={(e) =>
-                              handleInputChange(
-                                "courses",
-                                index,
-                                "category",
-                                e.target.value
-                              )
-                            }
-                            disabled={isSubmitted}
-                          />
-                        </div>
-
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                            Course Name*
-                          </label>
-                          <input
-                            type="text"
-                            placeholder="Course title"
-                            className={inputClasses}
-                            value={course.courseName}
-                            onChange={(e) =>
-                              handleInputChange(
-                                "courses",
-                                index,
-                                "courseName",
-                                e.target.value
-                              )
-                            }
-                            required
-                            disabled={isSubmitted}
-                          />
-                        </div>
-                      </div>
-                      <div className="flex justify-end pt-2">
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setDeleteTarget({ section: "courses", index });
-                            setIsModalOpen(true);
-                          }}
-                          className=" text-red-500 hover:text-red-700 transition"
-                          disabled={isSubmitted}
-                          title="Delete this course"
-                        >
-                          <TrashIcon className="w-5 h-5" />
-                        </button>
-                      </div>
-                    </div>
-                  ))}
-                </section>
-              )}
-              {sectionId === "pors" && (
-                <section className="mb-8">
-                  <div className="flex items-center justify-between mb-4">
-                    <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
-                      <span className="mr-2"></span> Positions of Responsibility
-                    </h2>
-                    <button
-                      type="button"
-                      onClick={() => addEntry("positions")}
-                      className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
-                      disabled={isSubmitted}
-                    >
-                      <PlusIcon className="w-5 h-5 mr-1" />
-                      Add Position
-                    </button>
-                  </div>
-
-                  {(resumeData.positions || []).map((position, index) => (
-                    <div key={index} className={sectionCardClasses}>
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                            Position Title*
-                          </label>
-                          <input
-                            type="text"
-                            placeholder="e.g. President, Secretary, etc."
-                            className={inputClasses}
-                            value={position.title}
-                            onChange={(e) =>
-                              handleInputChange(
-                                "positions",
-                                index,
-                                "title",
-                                e.target.value
-                              )
-                            }
-                            required
-                            disabled={isSubmitted}
-                          />
-                        </div>
-
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                            Organization*
-                          </label>
-                          <input
-                            type="text"
-                            placeholder="Organization name"
-                            className={inputClasses}
-                            value={position.organization}
-                            onChange={(e) =>
-                              handleInputChange(
-                                "positions",
-                                index,
-                                "organization",
-                                e.target.value
-                              )
-                            }
-                            required
-                            disabled={isSubmitted}
-                          />
-                        </div>
-
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                            Timeline
-                          </label>
-                          <input
-                            type="text"
-                            placeholder="e.g. 2022-2023"
-                            className={inputClasses}
-                            value={position.timeline}
-                            onChange={(e) =>
-                              handleInputChange(
-                                "positions",
-                                index,
-                                "timeline",
-                                e.target.value
-                              )
-                            }
-                            disabled={isSubmitted}
-                          />
-                        </div>
-                      </div>
-
-                      <div className="mt-4">
-                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                          Description
-                        </label>
-                        {position.description &&
-                          (position.description || []).map(
-                            (desc, descIndex) => (
-                              <div
-                                key={descIndex}
-                                className="flex items-center gap-2 mb-2"
-                              >
-                                <span className="text-gray-500 dark:text-gray-400">
-                                  •
-                                </span>
-                                <input
-                                  type="text"
-                                  placeholder={`Responsibility detail (${
-                                    descIndex + 1
-                                  })`}
-                                  className={`${inputClasses} flex-1`}
-                                  value={desc}
-                                  onChange={(e) => {
-                                    const updatedData = { ...resumeData };
-                                    updatedData.positions[index].description[
-                                      descIndex
-                                    ] = e.target.value;
-                                    setResumeData(updatedData);
-                                  }}
-                                  disabled={isSubmitted}
-                                />
-                                <button
-                                  type="button"
-                                  onClick={() => {
-                                    const updatedData = { ...resumeData };
-                                    updatedData.positions[
-                                      index
-                                    ].description.splice(descIndex, 1);
-                                    setResumeData(updatedData);
-                                  }}
-                                  className="text-red-500 hover:text-red-700 p-2 rounded-full hover:bg-red-50 dark:hover:bg-gray-700 transition"
-                                  title="Delete this description"
-                                  disabled={isSubmitted}
-                                >
-                                  <TrashIcon className="w-4 h-4" />
-                                </button>
-                              </div>
-                            )
-                          )}
-                        <button
-                          type="button"
-                          onClick={() => {
-                            const updatedData = { ...resumeData };
-
-                            if (!updatedData.positions) {
-                              updatedData.positions = [];
-                            }
-
-                            if (!updatedData.positions[index]) {
-                              updatedData.positions[index] = {
-                                description: [],
-                              };
-                            }
-
-                            if (
-                              !Array.isArray(
-                                updatedData.positions[index].description
-                              )
-                            ) {
-                              updatedData.positions[index].description = [];
-                            }
-
-                            updatedData.positions[index].description.push("");
-                            setResumeData(updatedData);
-                          }}
-                          className={`${buttonClasses} mt-2 bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 text-sm`}
-                          disabled={isSubmitted}
-                        >
-                          + Add Responsibility
-                        </button>
-                      </div>
-                      <div className="flex justify-end">
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setDeleteTarget({ section: "positions", index });
-                            setIsModalOpen(true);
-                          }}
-                          className=" text-red-500 hover:text-red-700 transition"
-                          disabled={isSubmitted}
-                          title="Delete this position"
-                        >
-                          <TrashIcon className="w-5 h-5" />
-                        </button>
-                      </div>
-                    </div>
-                  ))}
-                </section>
-              )}
-              {sectionId === "extracaurriculars" && (
-                <section className="mb-8">
-                  <div className="flex items-center justify-between mb-4">
-                    <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
-                      <span className="mr-2"></span> Extra-curriculars
-                    </h2>
-                    <button
-                      type="button"
-                      onClick={() => addEntry("extracaurriculars")}
-                      className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
-                      disabled={isSubmitted}
-                    >
-                      <PlusIcon className="w-5 h-5 mr-1" />
-                      Add Activity
-                    </button>
-                  </div>
-
-                  {(resumeData.extracaurriculars || []).map(
-                    (activity, index) => (
-                      <div key={index} className={sectionCardClasses}>
+                    {(resumeData.education || []).map((education, index) => (
+                        <div key={index} className={sectionCardClasses}>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                          <div>
+                            <div>
                             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                              Title*
+                                Degree/Certificate*
                             </label>
                             <input
-                              type="text"
-                              placeholder="Activity title"
-                              className={inputClasses}
-                              value={activity.title}
-                              onChange={(e) =>
+                                type="text"
+                                placeholder="e.g. Bachelor of Technology"
+                                className={inputClasses}
+                                value={education.degree}
+                                onChange={(e) =>
                                 handleInputChange(
-                                  "extracaurriculars",
-                                  index,
-                                  "title",
-                                  e.target.value
+                                    "education",
+                                    index,
+                                    "degree",
+                                    e.target.value
                                 )
-                              }
-                              required
-                              disabled={isSubmitted}
+                                }
+                                required
+                                disabled={isSubmitted}
                             />
-                          </div>
+                            </div>
 
-                          <div>
+                            <div>
                             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                              Organization
+                                Institute/Board*
                             </label>
                             <input
-                              type="text"
-                              placeholder="Organization name"
-                              className={inputClasses}
-                              value={activity.organization}
-                              onChange={(e) =>
+                                type="text"
+                                placeholder="e.g. University of XYZ"
+                                className={inputClasses}
+                                value={education.institute}
+                                onChange={(e) =>
                                 handleInputChange(
-                                  "extracaurriculars",
-                                  index,
-                                  "organization",
-                                  e.target.value
+                                    "education",
+                                    index,
+                                    "institute",
+                                    e.target.value
                                 )
-                              }
-                              disabled={isSubmitted}
+                                }
+                                required
+                                disabled={isSubmitted}
                             />
-                          </div>
+                            </div>
 
-                          <div>
+                            <div>
                             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                              Timeline
+                                CGPA/Percentage*
                             </label>
                             <input
-                              type="text"
-                              placeholder="e.g. 2021-2022"
-                              className={inputClasses}
-                              value={activity.timeline}
-                              onChange={(e) =>
+                                type="text"
+                                placeholder="e.g. 8.5 CGPA or 85\% (use \% for percentage or view instructions)"
+                                className={inputClasses}
+                                value={education.cgpa}
+                                onChange={(e) =>
                                 handleInputChange(
-                                  "extracaurriculars",
-                                  index,
-                                  "timeline",
-                                  e.target.value
+                                    "education",
+                                    index,
+                                    "cgpa",
+                                    e.target.value
                                 )
-                              }
-                              disabled={isSubmitted}
+                                }
+                                required
+                                disabled={isSubmitted}
                             />
-                          </div>
+                            </div>
+
+                            <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                Year*
+                            </label>
+                            <input
+                                type="text"
+                                placeholder="e.g. 2020-2024"
+                                className={inputClasses}
+                                value={education.year}
+                                onChange={(e) =>
+                                handleInputChange(
+                                    "education",
+                                    index,
+                                    "year",
+                                    e.target.value
+                                )
+                                }
+                                required
+                                disabled={isSubmitted}
+                            />
+                            </div>
+                        </div>
+                        <div className="flex justify-end">
+                            <button
+                            type="button"
+                            onClick={() => {
+                                setDeleteTarget({ section: "education", index });
+                                setIsModalOpen(true);
+                            }}
+                            className=" text-red-500 hover:text-red-700 transition"
+                            disabled={isSubmitted}
+                            title="Delete this education entry"
+                            >
+                            <TrashIcon className="w-5 h-5" />
+                            </button>
+                        </div>
+                        </div>
+                    ))}
+                    </section>
+                )}
+                {sectionId === "experience" && (
+                    <section className="">
+                    <div className="flex items-center justify-between mb-4">
+                        <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
+                        <span className="mr-2"></span> Experience
+                        </h2>
+                        <button
+                        type="button"
+                        onClick={() => addEntry("experience")}
+                        className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
+                        disabled={isSubmitted}
+                        >
+                        <PlusIcon className="w-5 h-5 mr-1" />
+                        Add Experience
+                        </button>
+                    </div>
+
+                    {(resumeData.experience || []).map((experience, index) => (
+                        <div key={index} className={sectionCardClasses}>
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                            <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                Company*
+                            </label>
+                            <input
+                                type="text"
+                                placeholder="Company name"
+                                className={inputClasses}
+                                value={experience.company}
+                                onChange={(e) =>
+                                handleInputChange(
+                                    "experience",
+                                    index,
+                                    "company",
+                                    e.target.value
+                                )
+                                }
+                                required
+                                disabled={isSubmitted}
+                            />
+                            </div>
+
+                            <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                Location
+                            </label>
+                            <input
+                                type="text"
+                                placeholder="e.g. Remote, Bangalore, etc."
+                                className={inputClasses}
+                                value={experience.location}
+                                onChange={(e) =>
+                                handleInputChange(
+                                    "experience",
+                                    index,
+                                    "location",
+                                    e.target.value
+                                )
+                                }
+                                disabled={isSubmitted}
+                                required
+                            />
+                            </div>
+
+                            <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                Role*
+                            </label>
+                            <input
+                                type="text"
+                                placeholder="Your position"
+                                className={inputClasses}
+                                value={experience.role}
+                                onChange={(e) =>
+                                handleInputChange(
+                                    "experience",
+                                    index,
+                                    "role",
+                                    e.target.value
+                                )
+                                }
+                                required
+                                disabled={isSubmitted}
+                            />
+                            </div>
+
+                            <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                Timeline*
+                            </label>
+                            <input
+                                type="text"
+                                placeholder="e.g. June 2022 - Present"
+                                className={inputClasses}
+                                value={experience.timeline}
+                                onChange={(e) =>
+                                handleInputChange(
+                                    "experience",
+                                    index,
+                                    "timeline",
+                                    e.target.value
+                                )
+                                }
+                                required
+                                disabled={isSubmitted}
+                            />
+                            </div>
                         </div>
 
                         <div className="mt-4">
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                            Description
-                          </label>
-                          {activity.description &&
-                            (activity.description || []).map(
-                              (desc, descIndex) => (
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                            Work Done
+                            </label>
+                            {experience.workDone &&
+                            (experience.workDone || []).map((task, taskIndex) => (
                                 <div
-                                  key={descIndex}
-                                  className="flex items-center gap-2 mb-2"
+                                key={taskIndex}
+                                className="flex items-center gap-2 mb-2"
                                 >
-                                  <span className="text-gray-500 dark:text-gray-400">
+                                <span className="text-gray-500 dark:text-gray-400">
                                     •
-                                  </span>
-                                  <input
+                                </span>
+                                <input
                                     type="text"
-                                    placeholder={`Activity detail (${
-                                      descIndex + 1
+                                    placeholder={`Describe your work (${
+                                    taskIndex + 1
+                                    })`}
+                                    className={`${inputClasses} flex-1`}
+                                    value={task}
+                                    onChange={(e) => {
+                                    const updatedData = { ...resumeData };
+                                    updatedData.experience[index].workDone[
+                                        taskIndex
+                                    ] = e.target.value;
+                                    setResumeData(updatedData);
+                                    }}
+                                    disabled={isSubmitted}
+                                />
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                    const updatedData = { ...resumeData };
+                                    updatedData.experience[index].workDone.splice(
+                                        taskIndex,
+                                        1
+                                    );
+                                    setResumeData(updatedData);
+                                    }}
+                                    className="text-red-500 hover:text-red-700 p-2 rounded-full hover:bg-red-50 dark:hover:bg-gray-700 transition"
+                                    title="Delete this task"
+                                    disabled={isSubmitted}
+                                >
+                                    <TrashIcon className="w-4 h-4" />
+                                </button>
+                                </div>
+                            ))}
+                            <button
+                            type="button"
+                            onClick={() => addWorkDone("experience", index)}
+                            className={`${buttonClasses} mt-2 bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 text-sm`}
+                            disabled={isSubmitted}
+                            >
+                            + Add Work Description
+                            </button>
+                        </div>
+
+                        <div className="flex justify-end">
+                            <button
+                            type="button"
+                            onClick={() => {
+                                setDeleteTarget({ section: "experience", index });
+                                setIsModalOpen(true);
+                            }}
+                            className=" text-red-500 hover:text-red-700 transition"
+                            disabled={isSubmitted}
+                            title="Delete this experience entry"
+                            >
+                            <TrashIcon className="w-5 h-5" />
+                            </button>
+                        </div>
+                        </div>
+                    ))}
+                    </section>
+                )}
+                {sectionId === "projects" && (
+                    <section className="">
+                    <div className="flex items-center justify-between mb-4">
+                        <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
+                        <span className="mr-2"></span> Projects
+                        </h2>
+                        <button
+                        type="button"
+                        onClick={() => addEntry("projects")}
+                        className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
+                        disabled={isSubmitted}
+                        >
+                        <PlusIcon className="w-5 h-5 mr-1" />
+                        Add Project
+                        </button>
+                    </div>
+
+                    {(resumeData.projects || []).map((project, index) => (
+                        <div key={index} className={sectionCardClasses}>
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                            <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                Project Name*
+                            </label>
+                            <input
+                                type="text"
+                                placeholder="Project title"
+                                className={inputClasses}
+                                value={project.name}
+                                onChange={(e) =>
+                                handleInputChange(
+                                    "projects",
+                                    index,
+                                    "name",
+                                    e.target.value
+                                )
+                                }
+                                required
+                                disabled={isSubmitted}
+                            />
+                            </div>
+
+                            <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                Project Type
+                            </label>
+                            <input
+                                type="text"
+                                placeholder="e.g. Web App, Research, etc."
+                                className={inputClasses}
+                                value={project.type}
+                                onChange={(e) =>
+                                handleInputChange(
+                                    "projects",
+                                    index,
+                                    "type",
+                                    e.target.value
+                                )
+                                }
+                                disabled={isSubmitted}
+                            />
+                            </div>
+
+                            <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                Timeline
+                            </label>
+                            <input
+                                type="text"
+                                placeholder="e.g. Jan 2023 - May 2023"
+                                className={inputClasses}
+                                value={project.timeline}
+                                onChange={(e) =>
+                                handleInputChange(
+                                    "projects",
+                                    index,
+                                    "timeline",
+                                    e.target.value
+                                )
+                                }
+                                disabled={isSubmitted}
+                            />
+                            </div>
+
+                            <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                GitHub Link
+                            </label>
+                            <input
+                                type="url"
+                                placeholder="Project repository URL"
+                                className={inputClasses}
+                                value={project.githubLink}
+                                onChange={(e) =>
+                                handleInputChange(
+                                    "projects",
+                                    index,
+                                    "githubLink",
+                                    e.target.value
+                                )
+                                }
+                                disabled={isSubmitted}
+                            />
+                            </div>
+                        </div>
+
+                        <div className="mt-4">
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                            Project Details
+                            </label>
+                            {project.workDone &&
+                            (project.workDone || []).map((task, taskIndex) => (
+                                <div
+                                key={taskIndex}
+                                className="flex items-center gap-2 mb-2"
+                                >
+                                <span className="text-gray-500 dark:text-gray-400">
+                                    •
+                                </span>
+                                <input
+                                    type="text"
+                                    placeholder={`Project detail (${
+                                    taskIndex + 1
+                                    })`}
+                                    className={`${inputClasses} flex-1`}
+                                    value={task}
+                                    onChange={(e) => {
+                                    const updatedData = { ...resumeData };
+                                    updatedData.projects[index].workDone[
+                                        taskIndex
+                                    ] = e.target.value;
+                                    setResumeData(updatedData);
+                                    }}
+                                    disabled={isSubmitted}
+                                />
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                    const updatedData = { ...resumeData };
+                                    updatedData.projects[index].workDone.splice(
+                                        taskIndex,
+                                        1
+                                    );
+                                    setResumeData(updatedData);
+                                    }}
+                                    className="text-red-500 hover:text-red-700 p-2 rounded-full hover:bg-red-50 dark:hover:bg-gray-700 transition"
+                                    title="Delete this detail"
+                                    disabled={isSubmitted}
+                                >
+                                    <TrashIcon className="w-4 h-4" />
+                                </button>
+                                </div>
+                            ))}
+                            <button
+                            type="button"
+                            onClick={() => {
+                                const updatedData = { ...resumeData };
+
+                                if (!updatedData.projects) {
+                                updatedData.projects = [];
+                                }
+                                if (!updatedData.projects[index]) {
+                                updatedData.projects[index] = {};
+                                }
+
+                                if (
+                                !Array.isArray(
+                                    updatedData.projects[index].workDone
+                                )
+                                ) {
+                                updatedData.projects[index].workDone = [];
+                                }
+
+                                updatedData.projects[index].workDone.push("");
+                                setResumeData(updatedData);
+                            }}
+                            className={`${buttonClasses} mt-2 bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 text-sm`}
+                            disabled={isSubmitted}
+                            >
+                            + Add Project Detail
+                            </button>
+                        </div>
+                        <div className="flex justify-end">
+                            <button
+                            type="button"
+                            onClick={() => {
+                                setDeleteTarget({ section: "projects", index });
+                                setIsModalOpen(true);
+                            }}
+                            className=" text-red-500 hover:text-red-700 transition"
+                            disabled={isSubmitted}
+                            title="Delete this project"
+                            >
+                            <TrashIcon className="w-5 h-5" />
+                            </button>
+                        </div>
+                        </div>
+                    ))}
+                    </section>
+                )}
+                {sectionId === "technicalSkills" && (
+                    <section className="">
+                    <div className="flex items-center justify-between mb-4">
+                        <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
+                        <span className="mr-2"></span> Technical Skills
+                        </h2>
+                        <button
+                        type="button"
+                        onClick={() => addEntry("technicalSkills")}
+                        className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
+                        disabled={isSubmitted}
+                        >
+                        <PlusIcon className="w-5 h-5 mr-1" />
+                        Add Skill
+                        </button>
+                    </div>
+
+                    {(resumeData.technicalSkills || []).map((skill, index) => (
+                        <div key={index} className={sectionCardClasses}>
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                Category*
+                            </label>
+                            <input
+                                type="text"
+                                placeholder="e.g. Programming Languages, Tools, etc."
+                                className={inputClasses}
+                                value={skill.category}
+                                onChange={(e) =>
+                                handleInputChange(
+                                    "technicalSkills",
+                                    index,
+                                    "category",
+                                    e.target.value
+                                )
+                                }
+                                required
+                                disabled={isSubmitted}
+                            />
+                            </div>
+
+                            <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                Skills*
+                            </label>
+                            <input
+                                type="text"
+                                placeholder="Comma separated list (e.g. Java, Python, C++)"
+                                className={inputClasses}
+                                value={skill.skills}
+                                onChange={(e) =>
+                                handleInputChange(
+                                    "technicalSkills",
+                                    index,
+                                    "skills",
+                                    e.target.value
+                                )
+                                }
+                                required
+                                disabled={isSubmitted}
+                            />
+                            </div>
+                        </div>
+                        <div className="flex justify-end pt-2">
+                            <button
+                            type="button"
+                            onClick={() => {
+                                setDeleteTarget({
+                                section: "technicalSkills",
+                                index,
+                                });
+                                setIsModalOpen(true);
+                            }}
+                            className=" text-red-500 hover:text-red-700 transition"
+                            disabled={isSubmitted}
+                            title="Delete this skill category"
+                            >
+                            <TrashIcon className="w-5 h-5" />
+                            </button>
+                        </div>
+                        </div>
+                    ))}
+                    </section>
+                )}
+                {sectionId === "courses" && (
+                    <section className="">
+                    <div className="flex items-center justify-between mb-4">
+                        <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
+                        <span className="mr-2"></span> Key Courses Taken
+                        </h2>
+                        <button
+                        type="button"
+                        onClick={() => addEntry("courses")}
+                        className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
+                        disabled={isSubmitted}
+                        >
+                        <PlusIcon className="w-5 h-5 mr-1" />
+                        Add Course
+                        </button>
+                    </div>
+
+                    {(resumeData.courses || []).map((course, index) => (
+                        <div key={index} className={sectionCardClasses}>
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                Category
+                            </label>
+                            <input
+                                type="text"
+                                placeholder="e.g. Core, Electives, etc."
+                                className={inputClasses}
+                                value={course.category}
+                                onChange={(e) =>
+                                handleInputChange(
+                                    "courses",
+                                    index,
+                                    "category",
+                                    e.target.value
+                                )
+                                }
+                                disabled={isSubmitted}
+                            />
+                            </div>
+
+                            <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                Course Name*
+                            </label>
+                            <input
+                                type="text"
+                                placeholder="Course title"
+                                className={inputClasses}
+                                value={course.courseName}
+                                onChange={(e) =>
+                                handleInputChange(
+                                    "courses",
+                                    index,
+                                    "courseName",
+                                    e.target.value
+                                )
+                                }
+                                required
+                                disabled={isSubmitted}
+                            />
+                            </div>
+                        </div>
+                        <div className="flex justify-end pt-2">
+                            <button
+                            type="button"
+                            onClick={() => {
+                                setDeleteTarget({ section: "courses", index });
+                                setIsModalOpen(true);
+                            }}
+                            className=" text-red-500 hover:text-red-700 transition"
+                            disabled={isSubmitted}
+                            title="Delete this course"
+                            >
+                            <TrashIcon className="w-5 h-5" />
+                            </button>
+                        </div>
+                        </div>
+                    ))}
+                    </section>
+                )}
+                {sectionId === "positions" && (
+                    <section className="">
+                    <div className="flex items-center justify-between mb-4">
+                        <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
+                        <span className="mr-2"></span> Positions of Responsibility
+                        </h2>
+                        <button
+                        type="button"
+                        onClick={() => addEntry("positions")}
+                        className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
+                        disabled={isSubmitted}
+                        >
+                        <PlusIcon className="w-5 h-5 mr-1" />
+                        Add Position
+                        </button>
+                    </div>
+
+                    {(resumeData.positions || []).map((position, index) => (
+                        <div key={index} className={sectionCardClasses}>
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                            <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                Position Title*
+                            </label>
+                            <input
+                                type="text"
+                                placeholder="e.g. President, Secretary, etc."
+                                className={inputClasses}
+                                value={position.title}
+                                onChange={(e) =>
+                                handleInputChange(
+                                    "positions",
+                                    index,
+                                    "title",
+                                    e.target.value
+                                )
+                                }
+                                required
+                                disabled={isSubmitted}
+                            />
+                            </div>
+
+                            <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                Organization*
+                            </label>
+                            <input
+                                type="text"
+                                placeholder="Organization name"
+                                className={inputClasses}
+                                value={position.organization}
+                                onChange={(e) =>
+                                handleInputChange(
+                                    "positions",
+                                    index,
+                                    "organization",
+                                    e.target.value
+                                )
+                                }
+                                required
+                                disabled={isSubmitted}
+                            />
+                            </div>
+
+                            <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                Timeline
+                            </label>
+                            <input
+                                type="text"
+                                placeholder="e.g. 2022-2023"
+                                className={inputClasses}
+                                value={position.timeline}
+                                onChange={(e) =>
+                                handleInputChange(
+                                    "positions",
+                                    index,
+                                    "timeline",
+                                    e.target.value
+                                )
+                                }
+                                disabled={isSubmitted}
+                            />
+                            </div>
+                        </div>
+
+                        <div className="mt-4">
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                            Description
+                            </label>
+                            {position.description &&
+                            (position.description || []).map(
+                                (desc, descIndex) => (
+                                <div
+                                    key={descIndex}
+                                    className="flex items-center gap-2 mb-2"
+                                >
+                                    <span className="text-gray-500 dark:text-gray-400">
+                                    •
+                                    </span>
+                                    <input
+                                    type="text"
+                                    placeholder={`Responsibility detail (${
+                                        descIndex + 1
                                     })`}
                                     className={`${inputClasses} flex-1`}
                                     value={desc}
                                     onChange={(e) => {
-                                      const updatedData = { ...resumeData };
-                                      updatedData.extracaurriculars[
-                                        index
-                                      ].description[descIndex] = e.target.value;
-                                      setResumeData(updatedData);
+                                        const updatedData = { ...resumeData };
+                                        updatedData.positions[index].description[
+                                        descIndex
+                                        ] = e.target.value;
+                                        setResumeData(updatedData);
                                     }}
                                     disabled={isSubmitted}
-                                  />
-                                  <button
+                                    />
+                                    <button
                                     type="button"
                                     onClick={() => {
-                                      const updatedData = { ...resumeData };
-                                      updatedData.extracaurriculars[
+                                        const updatedData = { ...resumeData };
+                                        updatedData.positions[
                                         index
-                                      ].description.splice(descIndex, 1);
-                                      setResumeData(updatedData);
+                                        ].description.splice(descIndex, 1);
+                                        setResumeData(updatedData);
                                     }}
                                     className="text-red-500 hover:text-red-700 p-2 rounded-full hover:bg-red-50 dark:hover:bg-gray-700 transition"
                                     title="Delete this description"
                                     disabled={isSubmitted}
-                                  >
+                                    >
                                     <TrashIcon className="w-4 h-4" />
-                                  </button>
+                                    </button>
                                 </div>
-                              )
+                                )
                             )}
-                          <button
+                            <button
                             type="button"
                             onClick={() => {
-                              const updatedData = { ...resumeData };
+                                const updatedData = { ...resumeData };
 
-                              if (!updatedData.extracaurriculars) {
-                                updatedData.extracaurriculars = [];
-                              }
+                                if (!updatedData.positions) {
+                                updatedData.positions = [];
+                                }
 
-                              if (!updatedData.extracaurriculars[index]) {
-                                updatedData.extracaurriculars[index] = {
-                                  description: [],
+                                if (!updatedData.positions[index]) {
+                                updatedData.positions[index] = {
+                                    description: [],
                                 };
-                              }
+                                }
 
-                              if (
+                                if (
                                 !Array.isArray(
-                                  updatedData.extracaurriculars[index]
-                                    .description
+                                    updatedData.positions[index].description
                                 )
-                              ) {
-                                updatedData.extracaurriculars[
-                                  index
-                                ].description = [];
-                              }
+                                ) {
+                                updatedData.positions[index].description = [];
+                                }
 
-                              updatedData.extracaurriculars[
-                                index
-                              ].description.push("");
-                              setResumeData(updatedData);
+                                updatedData.positions[index].description.push("");
+                                setResumeData(updatedData);
                             }}
                             className={`${buttonClasses} mt-2 bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 text-sm`}
                             disabled={isSubmitted}
-                          >
-                            + Add Description
-                          </button>
+                            >
+                            + Add Responsibility
+                            </button>
                         </div>
                         <div className="flex justify-end">
-                          <button
+                            <button
                             type="button"
                             onClick={() => {
-                              setDeleteTarget({
-                                section: "extracaurriculars",
-                                index,
-                              });
-                              setIsModalOpen(true);
+                                setDeleteTarget({ section: "positions", index });
+                                setIsModalOpen(true);
                             }}
-                            className="text-red-500 hover:text-red-700 transition"
+                            className=" text-red-500 hover:text-red-700 transition"
                             disabled={isSubmitted}
-                            title="Delete this activity"
-                          >
+                            title="Delete this position"
+                            >
                             <TrashIcon className="w-5 h-5" />
-                          </button>
+                            </button>
                         </div>
-                      </div>
-                    )
-                  )}
-                </section>
-              )}
-              {sectionId === "achievements" && (
-                <section className="mb-8">
-                  <div className="flex items-center justify-between mb-4">
-                    <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
-                      <span className="mr-2"></span> Achievements
-                    </h2>
-                    <button
-                      type="button"
-                      onClick={() => addEntry("achievements")}
-                      className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
-                      disabled={isSubmitted}
-                    >
-                      <PlusIcon className="w-5 h-5 mr-1" />
-                      Add Achievement
-                    </button>
-                  </div>
-
-                  {(resumeData.achievements || []).map((achievement, index) => (
-                    <div key={index} className={sectionCardClasses}>
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                            Achievement Title*
-                          </label>
-                          <input
-                            type="text"
-                            placeholder="e.g. First Place in Hackathon"
-                            className={inputClasses}
-                            value={achievement.title || ""}
-                            onChange={(e) =>
-                              handleInputChange(
-                                "achievements",
-                                index,
-                                "title",
-                                e.target.value
-                              )
-                            }
-                            required
-                            disabled={isSubmitted}
-                          />
                         </div>
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                            Description
-                          </label>
-                          <input
-                            type="text"
-                            placeholder="e.g. Developed a web app in 24 hours"
-                            className={inputClasses}
-                            value={achievement.description || ""}
-                            onChange={(e) =>
-                              handleInputChange(
-                                "achievements",
-                                index,
-                                "description",
-                                e.target.value
-                              )
-                            }
-                            disabled={isSubmitted}
-                          />
-                        </div>
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                            Year
-                          </label>
-                          <input
-                            type="text"
-                            placeholder="e.g. 2023"
-                            className={inputClasses}
-                            value={achievement.year || ""}
-                            onChange={(e) =>
-                              handleInputChange(
-                                "achievements",
-                                index,
-                                "year",
-                                e.target.value
-                              )
-                            }
-                            disabled={isSubmitted}
-                          />
-                        </div>
-                      </div>
-                      <div className="flex justify-end">
+                    ))}
+                    </section>
+                )}
+                {sectionId === "extracaurriculars" && (
+                    <section className="">
+                    <div className="flex items-center justify-between mb-4">
+                        <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
+                        <span className="mr-2"></span> Extra-curriculars
+                        </h2>
                         <button
-                          type="button"
-                          onClick={() => {
-                            setDeleteTarget({ section: "achievements", index });
-                            setIsModalOpen(true);
-                          }}
-                          className=" text-red-500 hover:text-red-700 transition"
-                          disabled={isSubmitted}
-                          title="Delete this achievement"
+                        type="button"
+                        onClick={() => addEntry("extracaurriculars")}
+                        className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
+                        disabled={isSubmitted}
                         >
-                          <TrashIcon className="w-5 h-5" />
+                        <PlusIcon className="w-5 h-5 mr-1" />
+                        Add Activity
                         </button>
-                      </div>
                     </div>
-                  ))}
-                </section>
-              )}
+
+                    {(resumeData.extracaurriculars || []).map(
+                        (activity, index) => (
+                        <div key={index} className={sectionCardClasses}>
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                Title*
+                                </label>
+                                <input
+                                type="text"
+                                placeholder="Activity title"
+                                className={inputClasses}
+                                value={activity.title}
+                                onChange={(e) =>
+                                    handleInputChange(
+                                    "extracaurriculars",
+                                    index,
+                                    "title",
+                                    e.target.value
+                                    )
+                                }
+                                required
+                                disabled={isSubmitted}
+                                />
+                            </div>
+
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                Organization
+                                </label>
+                                <input
+                                type="text"
+                                placeholder="Organization name"
+                                className={inputClasses}
+                                value={activity.organization}
+                                onChange={(e) =>
+                                    handleInputChange(
+                                    "extracaurriculars",
+                                    index,
+                                    "organization",
+                                    e.target.value
+                                    )
+                                }
+                                disabled={isSubmitted}
+                                />
+                            </div>
+
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                Timeline
+                                </label>
+                                <input
+                                type="text"
+                                placeholder="e.g. 2021-2022"
+                                className={inputClasses}
+                                value={activity.timeline}
+                                onChange={(e) =>
+                                    handleInputChange(
+                                    "extracaurriculars",
+                                    index,
+                                    "timeline",
+                                    e.target.value
+                                    )
+                                }
+                                disabled={isSubmitted}
+                                />
+                            </div>
+                            </div>
+
+                            <div className="mt-4">
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                                Description
+                            </label>
+                            {activity.description &&
+                                (activity.description || []).map(
+                                (desc, descIndex) => (
+                                    <div
+                                    key={descIndex}
+                                    className="flex items-center gap-2 mb-2"
+                                    >
+                                    <span className="text-gray-500 dark:text-gray-400">
+                                        •
+                                    </span>
+                                    <input
+                                        type="text"
+                                        placeholder={`Activity detail (${
+                                        descIndex + 1
+                                        })`}
+                                        className={`${inputClasses} flex-1`}
+                                        value={desc}
+                                        onChange={(e) => {
+                                        const updatedData = { ...resumeData };
+                                        updatedData.extracaurriculars[
+                                            index
+                                        ].description[descIndex] = e.target.value;
+                                        setResumeData(updatedData);
+                                        }}
+                                        disabled={isSubmitted}
+                                    />
+                                    <button
+                                        type="button"
+                                        onClick={() => {
+                                        const updatedData = { ...resumeData };
+                                        updatedData.extracaurriculars[
+                                            index
+                                        ].description.splice(descIndex, 1);
+                                        setResumeData(updatedData);
+                                        }}
+                                        className="text-red-500 hover:text-red-700 p-2 rounded-full hover:bg-red-50 dark:hover:bg-gray-700 transition"
+                                        title="Delete this description"
+                                        disabled={isSubmitted}
+                                    >
+                                        <TrashIcon className="w-4 h-4" />
+                                    </button>
+                                    </div>
+                                )
+                                )}
+                            <button
+                                type="button"
+                                onClick={() => {
+                                const updatedData = { ...resumeData };
+
+                                if (!updatedData.extracaurriculars) {
+                                    updatedData.extracaurriculars = [];
+                                }
+
+                                if (!updatedData.extracaurriculars[index]) {
+                                    updatedData.extracaurriculars[index] = {
+                                    description: [],
+                                    };
+                                }
+
+                                if (
+                                    !Array.isArray(
+                                    updatedData.extracaurriculars[index]
+                                        .description
+                                    )
+                                ) {
+                                    updatedData.extracaurriculars[
+                                    index
+                                    ].description = [];
+                                }
+
+                                updatedData.extracaurriculars[
+                                    index
+                                ].description.push("");
+                                setResumeData(updatedData);
+                                }}
+                                className={`${buttonClasses} mt-2 bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 text-sm`}
+                                disabled={isSubmitted}
+                            >
+                                + Add Description
+                            </button>
+                            </div>
+                            <div className="flex justify-end">
+                            <button
+                                type="button"
+                                onClick={() => {
+                                setDeleteTarget({
+                                    section: "extracaurriculars",
+                                    index,
+                                });
+                                setIsModalOpen(true);
+                                }}
+                                className="text-red-500 hover:text-red-700 transition"
+                                disabled={isSubmitted}
+                                title="Delete this activity"
+                            >
+                                <TrashIcon className="w-5 h-5" />
+                            </button>
+                            </div>
+                        </div>
+                        )
+                    )}
+                    </section>
+                )}
+                {sectionId === "achievements" && (
+                    <section className="">
+                    <div className="flex items-center justify-between mb-4">
+                        <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
+                        <span className="mr-2"></span> Achievements
+                        </h2>
+                        <button
+                        type="button"
+                        onClick={() => addEntry("achievements")}
+                        className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
+                        disabled={isSubmitted}
+                        >
+                        <PlusIcon className="w-5 h-5 mr-1" />
+                        Add Achievement
+                        </button>
+                    </div>
+
+                    {(resumeData.achievements || []).map((achievement, index) => (
+                        <div key={index} className={sectionCardClasses}>
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                Achievement Title*
+                            </label>
+                            <input
+                                type="text"
+                                placeholder="e.g. First Place in Hackathon"
+                                className={inputClasses}
+                                value={achievement.title || ""}
+                                onChange={(e) =>
+                                handleInputChange(
+                                    "achievements",
+                                    index,
+                                    "title",
+                                    e.target.value
+                                )
+                                }
+                                required
+                                disabled={isSubmitted}
+                            />
+                            </div>
+                            <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                Description
+                            </label>
+                            <input
+                                type="text"
+                                placeholder="e.g. Developed a web app in 24 hours"
+                                className={inputClasses}
+                                value={achievement.description || ""}
+                                onChange={(e) =>
+                                handleInputChange(
+                                    "achievements",
+                                    index,
+                                    "description",
+                                    e.target.value
+                                )
+                                }
+                                disabled={isSubmitted}
+                            />
+                            </div>
+                            <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                Year
+                            </label>
+                            <input
+                                type="text"
+                                placeholder="e.g. 2023"
+                                className={inputClasses}
+                                value={achievement.year || ""}
+                                onChange={(e) =>
+                                handleInputChange(
+                                    "achievements",
+                                    index,
+                                    "year",
+                                    e.target.value
+                                )
+                                }
+                                disabled={isSubmitted}
+                            />
+                            </div>
+                        </div>
+                        <div className="flex justify-end">
+                            <button
+                            type="button"
+                            onClick={() => {
+                                setDeleteTarget({ section: "achievements", index });
+                                setIsModalOpen(true);
+                            }}
+                            className=" text-red-500 hover:text-red-700 transition"
+                            disabled={isSubmitted}
+                            title="Delete this achievement"
+                            >
+                            <TrashIcon className="w-5 h-5" />
+                            </button>
+                        </div>
+                        </div>
+                    ))}
+                    </section>
+                )}
+            </div>
             </DraggableSection>
           ))}
         </SortableContext>

--- a/src/Components/ResumeBuilder.js
+++ b/src/Components/ResumeBuilder.js
@@ -1,226 +1,238 @@
-import { PlusIcon, TrashIcon } from '@heroicons/react/24/outline';
-import { useEffect, useRef, useState } from 'react';
-import axios from 'axios';
-import { useLatex } from './LatexContext';
-import '../styles/resumeBuilder.css';
-import isEqual from 'lodash.isequal';
-import Footer from './Footer';
-import toast from 'react-hot-toast';
+import { PlusIcon, TrashIcon } from "@heroicons/react/24/outline";
+import { useEffect, useRef, useState } from "react";
+import axios from "axios";
+import { useLatex } from "./LatexContext";
+import "../styles/resumeBuilder.css";
+import isEqual from "lodash.isequal";
+import Footer from "./Footer";
+import toast from "react-hot-toast";
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import DraggableSection from "./DraggableSection";
 
-const ResumeBuilder = ({ user, setUser, resumeData, setResumeData, errors, setErrors, latexCode, templates,darkMode }) => {
+const ResumeBuilder = ({
+  user,
+  setUser,
+  resumeData,
+  setResumeData,
+  errors,
+  setErrors,
+  latexCode,
+  templates,
+  darkMode,
+  sectionOrder
+}) => {
+  const { latexCodeE, setLatexCode } = useLatex();
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [progressLoding, setProgressLoading] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState({
+    section: null,
+    index: null,
+  });
 
-    const { latexCodeE, setLatexCode } = useLatex();
-    const [isSubmitted, setIsSubmitted] = useState(false);
-    const [progressLoding, setProgressLoading] = useState(false);
-    const [isModalOpen, setIsModalOpen] = useState(false);
-    const [deleteTarget, setDeleteTarget] = useState({ section: null, index: null });
+  const validate = () => {
+    let tempErrors = {};
+    // Validate personal information
+    if (!resumeData.personalInfo.name) tempErrors.name = "Name is required";
+    if (!resumeData.personalInfo.contactNumber)
+      tempErrors.contactNumber = "Contact Number is required";
+    if (!resumeData.personalInfo.email) tempErrors.email = "Email is required";
 
-    const validate = () => {
-        let tempErrors = {};
-        // Validate personal information
-        if (!resumeData.personalInfo.name) tempErrors.name = "Name is required";
-        if (!resumeData.personalInfo.contactNumber) tempErrors.contactNumber = "Contact Number is required";
-        if (!resumeData.personalInfo.email) tempErrors.email = "Email is required";
+    setErrors(tempErrors);
+    return Object.keys(tempErrors).length === 0; // Return true if no errors
+  };
 
-        setErrors(tempErrors);
-        return Object.keys(tempErrors).length === 0; // Return true if no errors
-    };
+  useEffect(() => {
+    setLatexCode(latexCode);
+  }, [latexCode]);
 
+  const handleInputChange = (section, index, field, value) => {
+    const updatedData = { ...resumeData };
+    updatedData[section][index][field] = value;
+    setResumeData(updatedData);
+  };
 
-    useEffect(() => {
-        setLatexCode(latexCode);
-    }, [latexCode])
+  const handlePersonalInfoChange = (field, value) => {
+    setResumeData({
+      ...resumeData,
+      personalInfo: {
+        ...resumeData.personalInfo,
+        [field]: value,
+      },
+    });
+  };
+  const requiredFields = {
+    experience: ["company", "role", "timeline", "location"],
+    projects: ["name", "type", "githubLink", "timeline"],
+    education: ["institute", "degree", "cgpa", "year"],
+    courses: ["category", "courseName"],
+    positions: ["title", "organization", "timeline"],
+    achievements: ["title", "description", "year"],
+    extracaurriculars: ["title", "organization", "timeline"],
+    technicalSkills: ["category", "skills"],
+  };
 
-    const handleInputChange = (section, index, field, value) => {
-        const updatedData = { ...resumeData };
-        updatedData[section][index][field] = value;
-        setResumeData(updatedData);
-    };
+  const addEntry = (section) => {
+    if (!templates || !templates[section]) return;
 
-    const handlePersonalInfoChange = (field, value) => {
-        setResumeData({
-            ...resumeData,
-            personalInfo: {
-                ...resumeData.personalInfo,
-                [field]: value,
-            },
-        });
-    };
-    const requiredFields = {
-        experience: ['company', 'role', 'timeline' , 'location'],
-        projects: ['name', 'type' , 'githubLink' , 'timeline'], 
-        education: ['institute', 'degree', 'cgpa' , 'year'],
-        courses: ['category', 'courseName'],
-        positions: ['title', 'organization', 'timeline'],
-        achievements: ['title', 'description', 'year'],
-        extracaurriculars: ['title', 'organization', 'timeline'],
-        technicalSkills: ['category', 'skills'],
-    };
-    
+    const currentEntries = resumeData[section] || [];
+    const lastEntry = currentEntries.at(-1);
+    if (lastEntry && requiredFields[section]) {
+      const missingField = requiredFields[section].some(
+        (field) =>
+          !lastEntry[field] || lastEntry[field].toString().trim() === ""
+      );
 
-    const addEntry = (section) => {
-        if (!templates || !templates[section]) return;
-      
-        const currentEntries = resumeData[section] || [];
-        const lastEntry = currentEntries.at(-1);
-        if (lastEntry && requiredFields[section]) {
-          const missingField = requiredFields[section].some(
-            (field) => !lastEntry[field] || lastEntry[field].toString().trim() === ''
-          );
-      
-          if (missingField) {
-            toast.error("Please complete the previous entry before adding a new one.");
-            return;
-          }
-        }
-      
-        setResumeData((prevData) => {
-          const updatedSection = [...(prevData[section] || []), templates[section]];
-          return {
-            ...prevData,
-            [section]: updatedSection,
-          };
-        });
+      if (missingField) {
+        toast.error(
+          "Please complete the previous entry before adding a new one."
+        );
+        return;
+      }
+    }
+
+    setResumeData((prevData) => {
+      const updatedSection = [...(prevData[section] || []), templates[section]];
+      return {
+        ...prevData,
+        [section]: updatedSection,
       };
-      
+    });
+  };
 
-    
+  const deleteEntry = (section, index) => {
+    setResumeData((prevData) => {
+      const updatedSection = [...(prevData[section] || [])];
+      updatedSection.splice(index, 1);
+      return {
+        ...prevData,
+        [section]: updatedSection,
+      };
+    });
+  };
 
-    const deleteEntry = (section, index) => {
-        setResumeData((prevData) => {
-            const updatedSection = [...(prevData[section] || [])];
-            updatedSection.splice(index, 1);
-            return {
-                ...prevData,
-                [section]: updatedSection,
-            };
-        });
-    };
+  const addWorkDone = (section, index) => {
+    const updatedData = { ...resumeData };
 
-    const addWorkDone = (section, index) => {
-        const updatedData = { ...resumeData };
+    if (!Array.isArray(updatedData[section])) {
+      updatedData[section] = [];
+    }
 
+    if (!updatedData[section][index]) {
+      updatedData[section][index] = { workDone: [] };
+    }
 
-        if (!Array.isArray(updatedData[section])) {
-            updatedData[section] = [];
-        }
+    if (!Array.isArray(updatedData[section][index].workDone)) {
+      updatedData[section][index].workDone = [];
+    }
 
+    updatedData[section][index].workDone.push("");
+    setResumeData(updatedData);
+  };
 
-        if (!updatedData[section][index]) {
-            updatedData[section][index] = { workDone: [] };
-        }
+  const prevDataRef = useRef(resumeData);
 
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      if (!isEqual(prevDataRef.current, resumeData)) {
+        const autoSave = async () => {
+          if (!user) return;
 
-        if (!Array.isArray(updatedData[section][index].workDone)) {
-            updatedData[section][index].workDone = [];
-        }
-
-
-        updatedData[section][index].workDone.push('');
-        setResumeData(updatedData);
-    };
-
-
-    const prevDataRef = useRef(resumeData);
-
-    useEffect(() => {
-        const handler = setTimeout(() => {
-            if (!isEqual(prevDataRef.current, resumeData)) {
-                const autoSave = async () => {
-                    if (!user) return;
-
-                    setProgressLoading(true);
-                    try {
-                        const response = await axios.put(
-                            `${process.env.REACT_APP_SERVER_URL}/saveprogress`,
-                            { resumeData },
-                            {
-                                withCredentials: true,
-                                headers: {
-                                    'Content-Type': 'application/json',
-                                },
-                            }
-                        );
-                        console.log('Auto-saved:', response.data);
-                        setUser(response.data.user);
-                        prevDataRef.current = resumeData; // Update previous after saving
-                    } catch (error) {
-                        console.error('Auto-save error:', error);
-                    } finally {
-                        setProgressLoading(false);
-                    }
-                };
-
-                autoSave();
-            }
-        }, 2000); // debounce time: 2s
-
-        return () => clearTimeout(handler); // clear timeout on cleanup
-    }, [resumeData]);
-
-
-    const handelProgress = async () => {
-        setProgressLoading(true);
-        try {
+          setProgressLoading(true);
+          try {
             const response = await axios.put(
-                `${process.env.REACT_APP_SERVER_URL}/saveprogress`,
-                { resumeData },
-                {
-                    withCredentials: true,
-                    headers: {
-                        'Content-Type': 'application/json',
-                    },
-                }
-            );
-            console.log('Progress saved:', response.data);
-            setUser(response.data.user);
-        } catch (error) {
-            console.error('Error saving progress:', error);
-        } finally {
-            setProgressLoading(false);
-        }
-    };
-
-
-
-    const handleSubmit = async (e) => {
-        e.preventDefault();
-        // return
-        if (!validate()) {
-            console.error('Validation failed:', errors);
-            return;
-        }
-        console.log('Form Submitted:', resumeData);
-        setIsSubmitted(true);
-
-        try {
-            const response = await axios.post(`${process.env.REACT_APP_SERVER_URL}/compile`, {
-                latexCode: latexCode
-            }, {
-                responseType: 'blob',
+              `${process.env.REACT_APP_SERVER_URL}/saveprogress`,
+              { resumeData },
+              {
+                withCredentials: true,
                 headers: {
-                    'Content-Type': 'application/json'
-                }
-            });
+                  "Content-Type": "application/json",
+                },
+              }
+            );
+            console.log("Auto-saved:", response.data);
+            setUser(response.data.user);
+            prevDataRef.current = resumeData; // Update previous after saving
+          } catch (error) {
+            console.error("Auto-save error:", error);
+          } finally {
+            setProgressLoading(false);
+          }
+        };
 
-            const blob = new Blob([response.data], { type: 'application/pdf' });
-            const url = window.URL.createObjectURL(blob);
-            const link = document.createElement('a');
-            link.href = url;
-            link.setAttribute('download', 'resume.pdf');
-            document.body.appendChild(link);
-            link.click();
-            link.remove();
-            window.URL.revokeObjectURL(url);
-            setIsSubmitted(false);
-        } catch (error) {
-            console.error('Error generating PDF:', error);
-            setIsSubmitted(false);
+        autoSave();
+      }
+    }, 2000); // debounce time: 2s
+
+    return () => clearTimeout(handler); // clear timeout on cleanup
+  }, [resumeData]);
+
+  const handelProgress = async () => {
+    setProgressLoading(true);
+    try {
+      const response = await axios.put(
+        `${process.env.REACT_APP_SERVER_URL}/saveprogress`,
+        { resumeData },
+        {
+          withCredentials: true,
+          headers: {
+            "Content-Type": "application/json",
+          },
         }
-    };
+      );
+      console.log("Progress saved:", response.data);
+      setUser(response.data.user);
+    } catch (error) {
+      console.error("Error saving progress:", error);
+    } finally {
+      setProgressLoading(false);
+    }
+  };
 
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    // return
+    if (!validate()) {
+      console.error("Validation failed:", errors);
+      return;
+    }
+    console.log("Form Submitted:", resumeData);
+    setIsSubmitted(true);
 
-    const inputClasses = `
+    try {
+      const response = await axios.post(
+        `${process.env.REACT_APP_SERVER_URL}/compile`,
+        {
+          latexCode: latexCode,
+        },
+        {
+          responseType: "blob",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+
+      const blob = new Blob([response.data], { type: "application/pdf" });
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", "resume.pdf");
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+      setIsSubmitted(false);
+    } catch (error) {
+      console.error("Error generating PDF:", error);
+      setIsSubmitted(false);
+    }
+  };
+
+  const inputClasses = `
         w-full px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-600
         bg-white dark:bg-gray-800 text-gray-900 dark:text-white
         placeholder-gray-500 dark:placeholder-gray-400
@@ -229,1094 +241,1469 @@ const ResumeBuilder = ({ user, setUser, resumeData, setResumeData, errors, setEr
         disabled:opacity-50 disabled:cursor-not-allowed
     `;
 
-
-    const buttonClasses = `
+  const buttonClasses = `
         px-4 py-2 rounded-lg font-medium transition duration-200 ease-in-out
         focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500
         disabled:opacity-50 disabled:cursor-not-allowed
     `;
 
-
-    const sectionCardClasses = `
+  const sectionCardClasses = `
         relative p-4 mb-4 rounded-lg border border-gray-200 dark:border-gray-700
         bg-white dark:bg-gray-800 shadow-sm hover:shadow-md transition duration-200
     `;
 
-    return (
-        <>
-        {isModalOpen && (
-    <div className="fixed inset-0 bg-black bg-opacity-40 z-50 flex items-center justify-center">
-        <div className="bg-white p-8 rounded-2xl shadow-2xl max-w-md w-[90%] text-center animate-fade-in">
-            <h2 className="text-2xl font-semibold text-gray-800 mb-3">Delete This Section?</h2>
+  return (
+    <>
+      {isModalOpen && (
+        <div className="fixed inset-0 bg-black bg-opacity-40 z-50 flex items-center justify-center">
+          <div className="bg-white p-8 rounded-2xl shadow-2xl max-w-md w-[90%] text-center animate-fade-in">
+            <h2 className="text-2xl font-semibold text-gray-800 mb-3">
+              Delete This Section?
+            </h2>
             <p className="text-gray-600 mb-6">
-    This will permanently delete an entry from your <span className="font-semibold text-gray-800">{deleteTarget.section}</span> section. Are you sure you want to continue?
-</p>
-            
+              This will permanently delete an entry from your{" "}
+              <span className="font-semibold text-gray-800">
+                {deleteTarget.section}
+              </span>{" "}
+              section. Are you sure you want to continue?
+            </p>
+
             <div className="flex justify-center space-x-4">
-                <button
-                    onClick={() => setIsModalOpen(false)}
-                    className="px-5 py-2.5 rounded-full bg-gray-100 text-gray-700 hover:bg-gray-200 transition font-medium"
-                >
-                    Cancel
-                </button>
-                <button
-                    onClick={() => {
-                        deleteEntry(deleteTarget.section, deleteTarget.index);
-                        setIsModalOpen(false);
-                    }}
-                    className="px-5 py-2.5 rounded-full bg-red-500 text-white hover:bg-red-600 transition font-medium"
-                >
-                    Delete
-                </button>
+              <button
+                onClick={() => setIsModalOpen(false)}
+                className="px-5 py-2.5 rounded-full bg-gray-100 text-gray-700 hover:bg-gray-200 transition font-medium"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => {
+                  deleteEntry(deleteTarget.section, deleteTarget.index);
+                  setIsModalOpen(false);
+                }}
+                className="px-5 py-2.5 rounded-full bg-red-500 text-white hover:bg-red-600 transition font-medium"
+              >
+                Delete
+              </button>
             </div>
+          </div>
         </div>
-    </div>
-)}
+      )}
 
-            <button className={`${buttonClasses} fixed z-50 transform -translate-y-1/2 ml-8 bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`} disabled={progressLoding} onClick={handelProgress}>Save Progress</button>
-            <form className="container mx-auto px-4 py-6 max-w-6xl" onSubmit={handleSubmit}>
-{/* ===== Resume Settings Section (Font Size) ===== */}
-<section className="mb-8 bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-gray-800 dark:to-gray-800 p-6 rounded-xl shadow-sm">
-  <h2 className="text-2xl font-bold mb-6 text-gray-800 dark:text-white">
-    Resume Settings
-  </h2>
+      <button
+        className={`${buttonClasses} fixed z-50 transform -translate-y-1/2 ml-8 bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
+        disabled={progressLoding}
+        onClick={handelProgress}
+      >
+        Save Progress
+      </button>
+      <form
+        className="container mx-auto px-4 py-6 max-w-6xl"
+        onSubmit={handleSubmit}
+      >
+        {/* ===== Resume Settings Section (Font Size) ===== */}
+        <section className="mb-8 bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-gray-800 dark:to-gray-800 p-6 rounded-xl shadow-sm">
+          <h2 className="text-2xl font-bold mb-6 text-gray-800 dark:text-white">
+            Resume Settings
+          </h2>
 
-  <div className="mb-4">
-    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-      Font Size (pt)
-    </label>
-    <input
-      type="number"
-      min="9"
-      max="12"
-      step="1"
-      value={resumeData.fontSize || 11}
-      onChange={(e) =>
-        setResumeData({
-          ...resumeData,
-          fontSize: parseInt(e.target.value, 10) || 11,
-        })
-      }
-      className={inputClasses}
-      disabled={isSubmitted}
-    />
-  </div>
-</section>
+          <div className="mb-4">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Font Size (pt)
+            </label>
+            <input
+              type="number"
+              min="9"
+              max="12"
+              step="1"
+              value={resumeData.fontSize || 11}
+              onChange={(e) =>
+                setResumeData({
+                  ...resumeData,
+                  fontSize: parseInt(e.target.value, 10) || 11,
+                })
+              }
+              className={inputClasses}
+              disabled={isSubmitted}
+            />
+          </div>
+        </section>
 
+        {/* Personal Information Section */}
+        <section className="mb-8 bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-gray-800 dark:to-gray-800 p-6 rounded-xl shadow-sm">
+          <h2 className="text-2xl font-bold mb-6 text-gray-800 dark:text-white flex items-center">
+            <span className="mr-2"></span> Personal Information
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Name*
+              </label>
+              <input
+                type="text"
+                placeholder="Your full name"
+                className={inputClasses}
+                value={resumeData.personalInfo.name}
+                onChange={(e) =>
+                  handlePersonalInfoChange("name", e.target.value)
+                }
+                required
+                disabled={isSubmitted}
+              />
+              {errors.name && (
+                <span className="text-sm text-red-600 mt-1">{errors.name}</span>
+              )}
+            </div>
 
-                {/* Personal Information Section */}
-                <section className="mb-8 bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-gray-800 dark:to-gray-800 p-6 rounded-xl shadow-sm">
-                    <h2 className="text-2xl font-bold mb-6 text-gray-800 dark:text-white flex items-center">
-                        <span className="mr-2"></span> Personal Information
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Roll Number*
+              </label>
+              <input
+                type="text"
+                placeholder="University roll number"
+                className={inputClasses}
+                value={resumeData.personalInfo.rollNumber}
+                onChange={(e) =>
+                  handlePersonalInfoChange("rollNumber", e.target.value)
+                }
+                disabled={isSubmitted}
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Course & Branch*
+              </label>
+              <input
+                type="text"
+                placeholder="e.g. B.Tech Computer Science"
+                className={inputClasses}
+                value={resumeData.personalInfo.courseBranch}
+                onChange={(e) =>
+                  handlePersonalInfoChange("courseBranch", e.target.value)
+                }
+                disabled={isSubmitted}
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Contact Number*
+              </label>
+              <input
+                type="tel"
+                placeholder="Phone number"
+                className={inputClasses}
+                value={resumeData.personalInfo.contactNumber}
+                onChange={(e) =>
+                  handlePersonalInfoChange("contactNumber", e.target.value)
+                }
+                required
+                disabled={isSubmitted}
+              />
+              {errors.contactNumber && (
+                <span className="text-sm text-red-600 mt-1">
+                  {errors.contactNumber}
+                </span>
+              )}
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                email*
+              </label>
+              <input
+                type="email"
+                placeholder="Your Email address"
+                className={inputClasses}
+                value={resumeData.personalInfo.email}
+                onChange={(e) =>
+                  handlePersonalInfoChange("email", e.target.value)
+                }
+                required
+                disabled={isSubmitted}
+              />
+              {errors.email && (
+                <span className="text-sm text-red-600 mt-1">
+                  {errors.secondaryEmail}
+                </span>
+              )}
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Secondary Email*
+              </label>
+              <input
+                type="email"
+                placeholder="Your secondary Email"
+                className={inputClasses}
+                value={resumeData.personalInfo.secondaryEmail}
+                onChange={(e) =>
+                  handlePersonalInfoChange("secondaryEmail", e.target.value)
+                }
+                required
+                disabled={isSubmitted}
+              />
+              {errors.email && (
+                <span className="text-sm text-red-600 mt-1">
+                  {errors.secondaryEmail}
+                </span>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                GitHub Profile
+              </label>
+              <input
+                type="url"
+                placeholder="https://github.com/username"
+                className={inputClasses}
+                value={resumeData.personalInfo.githubProfile}
+                onChange={(e) =>
+                  handlePersonalInfoChange("githubProfile", e.target.value)
+                }
+                disabled={isSubmitted}
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                LinkedIn Profile
+              </label>
+              <input
+                type="url"
+                placeholder="https://linkedin.com/in/username"
+                className={inputClasses}
+                value={resumeData.personalInfo.linkedinProfile}
+                onChange={(e) =>
+                  handlePersonalInfoChange("linkedinProfile", e.target.value)
+                }
+                disabled={isSubmitted}
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Website
+              </label>
+              <input
+                type="url"
+                placeholder="https://website.com"
+                className={inputClasses}
+                value={resumeData.personalInfo.website}
+                onChange={(e) =>
+                  handlePersonalInfoChange("website", e.target.value)
+                }
+                disabled={isSubmitted}
+              />
+            </div>
+          </div>
+        </section>
+
+        {/* Education Section */}
+        <SortableContext
+          items={sectionOrder}
+          strategy={verticalListSortingStrategy}>
+          {sectionOrder.map((sectionId) => (
+            <DraggableSection key={sectionId} id={sectionId}>
+              {sectionId === "education" && (
+                <section className="mb-8">
+                  <div className="flex items-center justify-between mb-4">
+                    <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
+                      <span className="mr-2"></span> Education
                     </h2>
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        <div>
-                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Name*</label>
-                            <input
-                                type="text"
-                                placeholder="Your full name"
-                                className={inputClasses}
-                                value={resumeData.personalInfo.name}
-                                onChange={(e) => handlePersonalInfoChange('name', e.target.value)}
-                                required
-                                disabled={isSubmitted}
-                            />
-                            {errors.name && <span className="text-sm text-red-600 mt-1">{errors.name}</span>}
-                        </div>
-
-                        <div>
-                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Roll Number*</label>
-                            <input
-                                type="text"
-                                placeholder="University roll number"
-                                className={inputClasses}
-                                value={resumeData.personalInfo.rollNumber}
-                                onChange={(e) => handlePersonalInfoChange('rollNumber', e.target.value)}
-                                disabled={isSubmitted}
-                            />
-                        </div>
-
-                        <div>
-                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Course & Branch*</label>
-                            <input
-                                type="text"
-                                placeholder="e.g. B.Tech Computer Science"
-                                className={inputClasses}
-                                value={resumeData.personalInfo.courseBranch}
-                                onChange={(e) => handlePersonalInfoChange('courseBranch', e.target.value)}
-                                disabled={isSubmitted}
-                            />
-                        </div>
-
-                        <div>
-                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Contact Number*</label>
-                            <input
-                                type="tel"
-                                placeholder="Phone number"
-                                className={inputClasses}
-                                value={resumeData.personalInfo.contactNumber}
-                                onChange={(e) => handlePersonalInfoChange('contactNumber', e.target.value)}
-                                required
-                                disabled={isSubmitted}
-                            />
-                            {errors.contactNumber && <span className="text-sm text-red-600 mt-1">{errors.contactNumber}</span>}
-                        </div>
-                        <div>
-                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">email*</label>
-                            <input
-                                type="email"
-                                placeholder="Your Email address"
-                                className={inputClasses}
-                                value={resumeData.personalInfo.email}
-                                onChange={(e) => handlePersonalInfoChange('email', e.target.value)}
-                                required
-                                disabled={isSubmitted}
-                            />
-                            {errors.email && <span className="text-sm text-red-600 mt-1">{errors.secondaryEmail}</span>}
-                        </div>
-                        <div>
-                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Secondary Email*</label>
-                            <input
-                                type="email"
-                                placeholder="Your secondary Email"
-                                className={inputClasses}
-                                value={resumeData.personalInfo.secondaryEmail}
-                                onChange={(e) => handlePersonalInfoChange('secondaryEmail', e.target.value)}
-                                required
-                                disabled={isSubmitted}
-                            />
-                            {errors.email && <span className="text-sm text-red-600 mt-1">{errors.secondaryEmail}</span>}
-                        </div>
-
-
-                        <div>
-                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">GitHub Profile</label>
-                            <input
-                                type="url"
-                                placeholder="https://github.com/username"
-                                className={inputClasses}
-                                value={resumeData.personalInfo.githubProfile}
-                                onChange={(e) => handlePersonalInfoChange('githubProfile', e.target.value)}
-                                disabled={isSubmitted}
-                            />
-                        </div>
-
-                        <div>
-                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">LinkedIn Profile</label>
-                            <input
-                                type="url"
-                                placeholder="https://linkedin.com/in/username"
-                                className={inputClasses}
-                                value={resumeData.personalInfo.linkedinProfile}
-                                onChange={(e) => handlePersonalInfoChange('linkedinProfile', e.target.value)}
-                                disabled={isSubmitted}
-                            />
-                        </div>
-
-                        <div>
-                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Website</label>
-                            <input
-                                type="url"
-                                placeholder="https://website.com"
-                                className={inputClasses}
-                                value={resumeData.personalInfo.website}
-                                onChange={(e) => handlePersonalInfoChange('website', e.target.value)}
-                                disabled={isSubmitted}
-                            />
-                        </div>
-                    </div>
-                </section>
-
-                {/* Education Section */}
-                <section className="mb-8">
-                    <div className="flex items-center justify-between mb-4">
-                        <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
-                            <span className="mr-2"></span> Education
-                        </h2>
-                        <button
-                            type="button"
-                            onClick={() => addEntry('education')}
-                            className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
-                            disabled={isSubmitted}
-                        >
-                            <PlusIcon className="w-5 h-5 mr-1" />
-                            Add Education
-                        </button>
-                    </div>
-
-                    {(resumeData.education || []).map((education, index) => (
-                        <div key={index} className={sectionCardClasses}>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Degree/Certificate*</label>
-                                    <input
-                                        type="text"
-                                        placeholder="e.g. Bachelor of Technology"
-                                        className={inputClasses}
-                                        value={education.degree}
-                                        onChange={(e) => handleInputChange('education', index, 'degree', e.target.value)}
-                                        required
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Institute/Board*</label>
-                                    <input
-                                        type="text"
-                                        placeholder="e.g. University of XYZ"
-                                        className={inputClasses}
-                                        value={education.institute}
-                                        onChange={(e) => handleInputChange('education', index, 'institute', e.target.value)}
-                                        required
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">CGPA/Percentage*</label>
-                                    <input
-                                        type="text"
-                                        placeholder="e.g. 8.5 CGPA or 85\% (use \% for percentage or view instructions)"
-                                        className={inputClasses}
-                                        value={education.cgpa}
-                                        onChange={(e) => handleInputChange('education', index, 'cgpa', e.target.value)}
-                                        required
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Year*</label>
-                                    <input
-                                        type="text"
-                                        placeholder="e.g. 2020-2024"
-                                        className={inputClasses}
-                                        value={education.year}
-                                        onChange={(e) => handleInputChange('education', index, 'year', e.target.value)}
-                                        required
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-                            </div>
-                            <div className="flex justify-end">
-                                <button
-                                    type="button"
-                                    onClick={() => {
-        setDeleteTarget({ section: 'education', index });
-        setIsModalOpen(true);
-    }}
-                                    className=" text-red-500 hover:text-red-700 transition"
-                                    disabled={isSubmitted}
-                                    title="Delete this education entry"
-                                >
-                                    <TrashIcon className="w-5 h-5" />
-                                </button>
-                            </div>
-
-
-                        </div>
-                    ))}
-                </section>
-
-                {/* Experience Section */}
-                <section className="mb-8">
-                    <div className="flex items-center justify-between mb-4">
-                        <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
-                            <span className="mr-2"></span> Experience
-                        </h2>
-                        <button
-                            type="button"
-                            onClick={() => addEntry('experience')}
-                            className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
-                            disabled={isSubmitted}
-                        >
-                            <PlusIcon className="w-5 h-5 mr-1" />
-                            Add Experience
-                        </button>
-                    </div>
-
-                    {(resumeData.experience || []).map((experience, index) => (
-                        <div key={index} className={sectionCardClasses}>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Company*</label>
-                                    <input
-                                        type="text"
-                                        placeholder="Company name"
-                                        className={inputClasses}
-                                        value={experience.company}
-                                        onChange={(e) => handleInputChange('experience', index, 'company', e.target.value)}
-                                        required
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Location</label>
-                                    <input
-                                        type="text"
-                                        placeholder="e.g. Remote, Bangalore, etc."
-                                        className={inputClasses}
-                                        value={experience.location}
-                                        onChange={(e) => handleInputChange('experience', index, 'location', e.target.value)}
-                                        disabled={isSubmitted}
-                                        required
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Role*</label>
-                                    <input
-                                        type="text"
-                                        placeholder="Your position"
-                                        className={inputClasses}
-                                        value={experience.role}
-                                        onChange={(e) => handleInputChange('experience', index, 'role', e.target.value)}
-                                        required
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Timeline*</label>
-                                    <input
-                                        type="text"
-                                        placeholder="e.g. June 2022 - Present"
-                                        className={inputClasses}
-                                        value={experience.timeline}
-                                        onChange={(e) => handleInputChange('experience', index, 'timeline', e.target.value)}
-                                        required
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-                            </div>
-
-                            <div className="mt-4">
-                                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Work Done</label>
-                                {experience.workDone && (experience.workDone || []).map((task, taskIndex) => (
-                                    <div key={taskIndex} className="flex items-center gap-2 mb-2">
-                                        <span className="text-gray-500 dark:text-gray-400">•</span>
-                                        <input
-                                            type="text"
-                                            placeholder={`Describe your work (${taskIndex + 1})`}
-                                            className={`${inputClasses} flex-1`}
-                                            value={task}
-                                            onChange={(e) => {
-                                                const updatedData = { ...resumeData };
-                                                updatedData.experience[index].workDone[taskIndex] = e.target.value;
-                                                setResumeData(updatedData);
-                                            }}
-                                            disabled={isSubmitted}
-                                        />
-                                        <button
-                                            type='button'
-                                            onClick={() => {
-                                                const updatedData = { ...resumeData };
-                                                updatedData.experience[index].workDone.splice(taskIndex, 1);
-                                                setResumeData(updatedData);
-                                            }}
-                                            className="text-red-500 hover:text-red-700 p-2 rounded-full hover:bg-red-50 dark:hover:bg-gray-700 transition"
-                                            title="Delete this task"
-                                            disabled={isSubmitted}
-                                        >
-                                            <TrashIcon className="w-4 h-4" />
-                                        </button>
-                                    </div>
-                                ))}
-                                <button
-                                    type='button'
-                                    onClick={() => addWorkDone('experience', index)}
-                                    className={`${buttonClasses} mt-2 bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 text-sm`}
-                                    disabled={isSubmitted}
-                                >
-                                    + Add Work Description
-                                </button>
-                            </div>
-
-                            <div className="flex justify-end">
-
-
-                                <button
-                                    type="button"
-                                    onClick={() => {
-    setDeleteTarget({ section: 'experience', index });
-    setIsModalOpen(true);
-}}
-                                    className=" text-red-500 hover:text-red-700 transition"
-                                    disabled={isSubmitted}
-                                    title="Delete this experience entry"
-                                >
-                                    <TrashIcon className="w-5 h-5" />
-                                </button>
-                            </div>
-                        </div>
-                    ))}
-                </section>
-
-                {/* Projects Section */}
-                <section className="mb-8">
-                    <div className="flex items-center justify-between mb-4">
-                        <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
-                            <span className="mr-2"></span> Projects
-                        </h2>
-                        <button
-                            type="button"
-                            onClick={() => addEntry('projects')}
-                            className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
-                            disabled={isSubmitted}
-                        >
-                            <PlusIcon className="w-5 h-5 mr-1" />
-                            Add Project
-                        </button>
-                    </div>
-
-                    {(resumeData.projects || []).map((project, index) => (
-                        <div key={index} className={sectionCardClasses}>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Project Name*</label>
-                                    <input
-                                        type="text"
-                                        placeholder="Project title"
-                                        className={inputClasses}
-                                        value={project.name}
-                                        onChange={(e) => handleInputChange('projects', index, 'name', e.target.value)}
-                                        required
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Project Type</label>
-                                    <input
-                                        type="text"
-                                        placeholder="e.g. Web App, Research, etc."
-                                        className={inputClasses}
-                                        value={project.type}
-                                        onChange={(e) => handleInputChange('projects', index, 'type', e.target.value)}
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Timeline</label>
-                                    <input
-                                        type="text"
-                                        placeholder="e.g. Jan 2023 - May 2023"
-                                        className={inputClasses}
-                                        value={project.timeline}
-                                        onChange={(e) => handleInputChange('projects', index, 'timeline', e.target.value)}
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">GitHub Link</label>
-                                    <input
-                                        type="url"
-                                        placeholder="Project repository URL"
-                                        className={inputClasses}
-                                        value={project.githubLink}
-                                        onChange={(e) => handleInputChange('projects', index, 'githubLink', e.target.value)}
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-                            </div>
-
-                            <div className="mt-4">
-                                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Project Details</label>
-                                {project.workDone && (project.workDone || []).map((task, taskIndex) => (
-                                    <div key={taskIndex} className="flex items-center gap-2 mb-2">
-                                        <span className="text-gray-500 dark:text-gray-400">•</span>
-                                        <input
-                                            type="text"
-                                            placeholder={`Project detail (${taskIndex + 1})`}
-                                            className={`${inputClasses} flex-1`}
-                                            value={task}
-                                            onChange={(e) => {
-                                                const updatedData = { ...resumeData };
-                                                updatedData.projects[index].workDone[taskIndex] = e.target.value;
-                                                setResumeData(updatedData);
-                                            }}
-                                            disabled={isSubmitted}
-                                        />
-                                        <button
-                                            type='button'
-                                            onClick={() => {
-                                                const updatedData = { ...resumeData };
-                                                updatedData.projects[index].workDone.splice(taskIndex, 1);
-                                                setResumeData(updatedData);
-                                            }}
-                                            className="text-red-500 hover:text-red-700 p-2 rounded-full hover:bg-red-50 dark:hover:bg-gray-700 transition"
-                                            title="Delete this detail"
-                                            disabled={isSubmitted}
-                                        >
-                                            <TrashIcon className="w-4 h-4" />
-                                        </button>
-                                    </div>
-                                ))}
-                                <button
-                                    type='button'
-                                    onClick={() => {
-                                        const updatedData = { ...resumeData };
-
-
-                                        if (!updatedData.projects) {
-                                            updatedData.projects = [];
-                                        }
-                                        if (!updatedData.projects[index]) {
-                                            updatedData.projects[index] = {};
-                                        }
-
-
-                                        if (!Array.isArray(updatedData.projects[index].workDone)) {
-                                            updatedData.projects[index].workDone = [];
-                                        }
-
-
-                                        updatedData.projects[index].workDone.push('');
-                                        setResumeData(updatedData);
-                                    }}
-
-                                    className={`${buttonClasses} mt-2 bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 text-sm`}
-                                    disabled={isSubmitted}
-                                >
-                                    + Add Project Detail
-                                </button>
-                            </div>
-                            <div className="flex justify-end">
-                                <button
-                                    type="button"
-                                    onClick={() => {
-    setDeleteTarget({ section: 'projects', index });
-    setIsModalOpen(true);
-}}
-                                    className=" text-red-500 hover:text-red-700 transition"
-                                    disabled={isSubmitted}
-                                    title="Delete this project"
-                                >
-                                    <TrashIcon className="w-5 h-5" />
-                                </button></div>
-                        </div>
-                    ))}
-                </section>
-
-                {/* Technical Skills Section */}
-                <section className="mb-8">
-                    <div className="flex items-center justify-between mb-4">
-                        <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
-                            <span className="mr-2"></span> Technical Skills
-                        </h2>
-                        <button
-                            type="button"
-                            onClick={() => addEntry('technicalSkills')}
-                            className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
-                            disabled={isSubmitted}
-                        >
-                            <PlusIcon className="w-5 h-5 mr-1" />
-                            Add Skill
-                        </button>
-                    </div>
-
-                    {(resumeData.technicalSkills || []).map((skill, index) => (
-                        <div key={index} className={sectionCardClasses}>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Category*</label>
-                                    <input
-                                        type="text"
-                                        placeholder="e.g. Programming Languages, Tools, etc."
-                                        className={inputClasses}
-                                        value={skill.category}
-                                        onChange={(e) => handleInputChange('technicalSkills', index, 'category', e.target.value)}
-                                        required
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Skills*</label>
-                                    <input
-                                        type="text"
-                                        placeholder="Comma separated list (e.g. Java, Python, C++)"
-                                        className={inputClasses}
-                                        value={skill.skills}
-                                        onChange={(e) => handleInputChange('technicalSkills', index, 'skills', e.target.value)}
-                                        required
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-                            </div>
-                            <div className="flex justify-end pt-2">
-                                <button
-                                    type="button"
-                                    onClick={() => {
-    setDeleteTarget({ section: 'technicalSkills', index });
-    setIsModalOpen(true);
-}}
-                                    className=" text-red-500 hover:text-red-700 transition"
-                                    disabled={isSubmitted}
-                                    title="Delete this skill category"
-                                >
-                                    <TrashIcon className="w-5 h-5" />
-                                </button></div>
-                        </div>
-                    ))}
-                </section>
-
-                {/* Key Courses Taken Section */}
-                <section className="mb-8">
-                    <div className="flex items-center justify-between mb-4">
-                        <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
-                            <span className="mr-2"></span> Key Courses Taken
-                        </h2>
-                        <button
-                            type="button"
-                            onClick={() => addEntry('courses')}
-                            className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
-                            disabled={isSubmitted}
-                        >
-                            <PlusIcon className="w-5 h-5 mr-1" />
-                            Add Course
-                        </button>
-                    </div>
-
-                    {(resumeData.courses || []).map((course, index) => (
-                        <div key={index} className={sectionCardClasses}>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Category</label>
-                                    <input
-                                        type="text"
-                                        placeholder="e.g. Core, Electives, etc."
-                                        className={inputClasses}
-                                        value={course.category}
-                                        onChange={(e) => handleInputChange('courses', index, 'category', e.target.value)}
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Course Name*</label>
-                                    <input
-                                        type="text"
-                                        placeholder="Course title"
-                                        className={inputClasses}
-                                        value={course.courseName}
-                                        onChange={(e) => handleInputChange('courses', index, 'courseName', e.target.value)}
-                                        required
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-                            </div>
-                            <div className="flex justify-end pt-2">
-                                <button
-                                    type="button"
-                                    onClick={() => {
-    setDeleteTarget({ section: 'courses', index });
-    setIsModalOpen(true);
-}}
-                                    className=" text-red-500 hover:text-red-700 transition"
-                                    disabled={isSubmitted}
-                                    title="Delete this course"
-                                >
-                                    <TrashIcon className="w-5 h-5" />
-                                </button></div>
-                        </div>
-                    ))}
-                </section>
-
-                {/* Positions of Responsibility Section */}
-                <section className="mb-8">
-                    <div className="flex items-center justify-between mb-4">
-                        <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
-                            <span className="mr-2"></span> Positions of Responsibility
-                        </h2>
-                        <button
-                            type="button"
-                            onClick={() => addEntry('positions')}
-                            className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
-                            disabled={isSubmitted}
-                        >
-                            <PlusIcon className="w-5 h-5 mr-1" />
-                            Add Position
-                        </button>
-                    </div>
-
-                    {(resumeData.positions || []).map((position, index) => (
-                        <div key={index} className={sectionCardClasses}>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Position Title*</label>
-                                    <input
-                                        type="text"
-                                        placeholder="e.g. President, Secretary, etc."
-                                        className={inputClasses}
-                                        value={position.title}
-                                        onChange={(e) => handleInputChange('positions', index, 'title', e.target.value)}
-                                        required
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Organization*</label>
-                                    <input
-                                        type="text"
-                                        placeholder="Organization name"
-                                        className={inputClasses}
-                                        value={position.organization}
-                                        onChange={(e) => handleInputChange('positions', index, 'organization', e.target.value)}
-                                        required
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Timeline</label>
-                                    <input
-                                        type="text"
-                                        placeholder="e.g. 2022-2023"
-                                        className={inputClasses}
-                                        value={position.timeline}
-                                        onChange={(e) => handleInputChange('positions', index, 'timeline', e.target.value)}
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-                            </div>
-
-                            <div className="mt-4">
-                                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Description</label>
-                                {position.description && (position.description || []).map((desc, descIndex) => (
-                                    <div key={descIndex} className="flex items-center gap-2 mb-2">
-                                        <span className="text-gray-500 dark:text-gray-400">•</span>
-                                        <input
-                                            type="text"
-                                            placeholder={`Responsibility detail (${descIndex + 1})`}
-                                            className={`${inputClasses} flex-1`}
-                                            value={desc}
-                                            onChange={(e) => {
-                                                const updatedData = { ...resumeData };
-                                                updatedData.positions[index].description[descIndex] = e.target.value;
-                                                setResumeData(updatedData);
-                                            }}
-                                            disabled={isSubmitted}
-                                        />
-                                        <button
-                                            type='button'
-                                            onClick={() => {
-                                                const updatedData = { ...resumeData };
-                                                updatedData.positions[index].description.splice(descIndex, 1);
-                                                setResumeData(updatedData);
-                                            }}
-                                            className="text-red-500 hover:text-red-700 p-2 rounded-full hover:bg-red-50 dark:hover:bg-gray-700 transition"
-                                            title="Delete this description"
-                                            disabled={isSubmitted}
-                                        >
-                                            <TrashIcon className="w-4 h-4" />
-                                        </button>
-                                    </div>
-                                ))}
-                                <button
-                                    type='button'
-                                    onClick={() => {
-                                        const updatedData = { ...resumeData };
-
-
-                                        if (!updatedData.positions) {
-                                            updatedData.positions = [];
-                                        }
-
-
-                                        if (!updatedData.positions[index]) {
-                                            updatedData.positions[index] = { description: [] };
-                                        }
-
-
-                                        if (!Array.isArray(updatedData.positions[index].description)) {
-                                            updatedData.positions[index].description = [];
-                                        }
-
-
-                                        updatedData.positions[index].description.push('');
-                                        setResumeData(updatedData);
-                                    }}
-                                    className={`${buttonClasses} mt-2 bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 text-sm`}
-                                    disabled={isSubmitted}
-                                >
-                                    + Add Responsibility
-                                </button>
-                            </div>
-                            <div className="flex justify-end">
-                                <button
-                                    type="button"
-                                    onClick={() => {
-    setDeleteTarget({ section: 'positions', index });
-    setIsModalOpen(true);
-}}
-                                    className=" text-red-500 hover:text-red-700 transition"
-                                    disabled={isSubmitted}
-                                    title="Delete this position"
-                                >
-                                    <TrashIcon className="w-5 h-5" />
-                                </button></div>
-                        </div>
-                    ))}
-                </section>
-
-                {/* Extra-curriculars Section */}
-                <section className="mb-8">
-                    <div className="flex items-center justify-between mb-4">
-                        <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
-                            <span className="mr-2"></span> Extra-curriculars
-                        </h2>
-                        <button
-                            type="button"
-                            onClick={() => addEntry('extracaurriculars')}
-                            className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
-                            disabled={isSubmitted}
-                        >
-                            <PlusIcon className="w-5 h-5 mr-1" />
-                            Add Activity
-                        </button>
-                    </div>
-
-                    {(resumeData.extracaurriculars || []).map((activity, index) => (
-                        <div key={index} className={sectionCardClasses}>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Title*</label>
-                                    <input
-                                        type="text"
-                                        placeholder="Activity title"
-                                        className={inputClasses}
-                                        value={activity.title}
-                                        onChange={(e) => handleInputChange('extracaurriculars', index, 'title', e.target.value)}
-                                        required
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Organization</label>
-                                    <input
-                                        type="text"
-                                        placeholder="Organization name"
-                                        className={inputClasses}
-                                        value={activity.organization}
-                                        onChange={(e) => handleInputChange('extracaurriculars', index, 'organization', e.target.value)}
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Timeline</label>
-                                    <input
-                                        type="text"
-                                        placeholder="e.g. 2021-2022"
-                                        className={inputClasses}
-                                        value={activity.timeline}
-                                        onChange={(e) => handleInputChange('extracaurriculars', index, 'timeline', e.target.value)}
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-                            </div>
-
-                            <div className="mt-4">
-                                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Description</label>
-                                {activity.description && (activity.description || []).map((desc, descIndex) => (
-                                    <div key={descIndex} className="flex items-center gap-2 mb-2">
-                                        <span className="text-gray-500 dark:text-gray-400">•</span>
-                                        <input
-                                            type="text"
-                                            placeholder={`Activity detail (${descIndex + 1})`}
-                                            className={`${inputClasses} flex-1`}
-                                            value={desc}
-                                            onChange={(e) => {
-                                                const updatedData = { ...resumeData };
-                                                updatedData.extracaurriculars[index].description[descIndex] = e.target.value;
-                                                setResumeData(updatedData);
-                                            }}
-                                            disabled={isSubmitted}
-                                        />
-                                        <button
-                                            type='button'
-                                            onClick={() => {
-                                                const updatedData = { ...resumeData };
-                                                updatedData.extracaurriculars[index].description.splice(descIndex, 1);
-                                                setResumeData(updatedData);
-                                            }}
-                                            className="text-red-500 hover:text-red-700 p-2 rounded-full hover:bg-red-50 dark:hover:bg-gray-700 transition"
-                                            title="Delete this description"
-                                            disabled={isSubmitted}
-                                        >
-                                            <TrashIcon className="w-4 h-4" />
-                                        </button>
-                                    </div>
-                                ))}
-                                <button
-                                    type='button'
-                                    onClick={() => {
-                                        const updatedData = { ...resumeData };
-
-
-                                        if (!updatedData.extracaurriculars) {
-                                            updatedData.extracaurriculars = [];
-                                        }
-
-
-                                        if (!updatedData.extracaurriculars[index]) {
-                                            updatedData.extracaurriculars[index] = { description: [] };
-                                        }
-
-
-                                        if (!Array.isArray(updatedData.extracaurriculars[index].description)) {
-                                            updatedData.extracaurriculars[index].description = [];
-                                        }
-
-
-                                        updatedData.extracaurriculars[index].description.push('');
-                                        setResumeData(updatedData);
-                                    }}
-                                    className={`${buttonClasses} mt-2 bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 text-sm`}
-                                    disabled={isSubmitted}
-                                >
-                                    + Add Description
-                                </button>
-                            </div>
-                            <div className="flex justify-end">
-                                <button
-                                    type="button"
-                                    onClick={() => {
-    setDeleteTarget({ section: 'extracaurriculars', index });
-    setIsModalOpen(true);
-}}
-                                    className="text-red-500 hover:text-red-700 transition"
-                                    disabled={isSubmitted}
-                                    title="Delete this activity"
-                                >
-                                    <TrashIcon className="w-5 h-5" />
-                                </button></div>
-                        </div>
-                    ))}
-                </section>
-
-                {/* Achievements Section */}
-                <section className="mb-8">
-                    <div className="flex items-center justify-between mb-4">
-                        <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
-                            <span className="mr-2"></span> Achievements
-                        </h2>
-                        <button
-                            type="button"
-                            onClick={() => addEntry('achievements')}
-                            className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
-                            disabled={isSubmitted}
-                        >
-                            <PlusIcon className="w-5 h-5 mr-1" />
-                            Add Achievement
-                        </button>
-                    </div>
-
-                    {(resumeData.achievements || []).map((achievement, index) => (
-                        <div key={index} className={sectionCardClasses}>
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Achievement Title*</label>
-                                    <input
-                                        type="text"
-                                        placeholder="e.g. First Place in Hackathon"
-                                        className={inputClasses}
-                                        value={achievement.title || ''}
-                                        onChange={(e) => handleInputChange('achievements', index, 'title', e.target.value)}
-                                        required
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Description</label>
-                                    <input
-                                        type="text"
-                                        placeholder="e.g. Developed a web app in 24 hours"
-                                        className={inputClasses}
-                                        value={achievement.description || ''}
-                                        onChange={(e) => handleInputChange('achievements', index, 'description', e.target.value)}
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-                                <div>
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Year</label>
-                                    <input
-                                        type="text"
-                                        placeholder="e.g. 2023"
-                                        className={inputClasses}
-                                        value={achievement.year || ''}
-                                        onChange={(e) => handleInputChange('achievements', index, 'year', e.target.value)}
-                                        disabled={isSubmitted}
-                                    />
-                                </div>
-                            </div>
-                            <div className="flex justify-end">
-                                <button
-                                    type="button"
-                                    onClick={() => {
-    setDeleteTarget({ section: 'achievements', index });
-    setIsModalOpen(true);
-}}
-                                    className=" text-red-500 hover:text-red-700 transition"
-                                    disabled={isSubmitted}
-                                    title="Delete this achievement"
-                                >
-                                    <TrashIcon className="w-5 h-5" />
-                                </button>
-                            </div>
-                        </div>
-                    ))}
-                </section>
-
-                {/* Submit Button */}
-                <div className="flex justify-end mt-8">
                     <button
-                        type="submit"
-                        className={`${buttonClasses} bg-blue-600 text-white hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-600 flex items-center space-x-2`}
-                        disabled={isSubmitted}
-                    // onClick={handleSubmit}
+                      type="button"
+                      onClick={() => addEntry("education")}
+                      className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
+                      disabled={isSubmitted}
                     >
-                        {isSubmitted ? (
-                            <>
-                                <svg
-                                    className="animate-spin h-5 w-5 text-white"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    fill="none"
-                                    viewBox="0 0 24 24"
-                                >
-                                    <circle
-                                        className="opacity-25"
-                                        cx="12"
-                                        cy="12"
-                                        r="10"
-                                        stroke="currentColor"
-                                        strokeWidth="4"
-                                    ></circle>
-                                    <path
-                                        className="opacity-75"
-                                        fill="currentColor"
-                                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                                    ></path>
-                                </svg>
-                                <span>Generating...</span>
-                            </>
-                        ) : (
-                            <span>Generate Resume</span>
-                        )}
+                      <PlusIcon className="w-5 h-5 mr-1" />
+                      Add Education
                     </button>
-                </div>
+                  </div>
 
-            </form>
-            <Footer darkMode={darkMode}></Footer>
-        </>
-    );
+                  {(resumeData.education || []).map((education, index) => (
+                    <div key={index} className={sectionCardClasses}>
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                        <div>
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Degree/Certificate*
+                          </label>
+                          <input
+                            type="text"
+                            placeholder="e.g. Bachelor of Technology"
+                            className={inputClasses}
+                            value={education.degree}
+                            onChange={(e) =>
+                              handleInputChange(
+                                "education",
+                                index,
+                                "degree",
+                                e.target.value
+                              )
+                            }
+                            required
+                            disabled={isSubmitted}
+                          />
+                        </div>
+
+                        <div>
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Institute/Board*
+                          </label>
+                          <input
+                            type="text"
+                            placeholder="e.g. University of XYZ"
+                            className={inputClasses}
+                            value={education.institute}
+                            onChange={(e) =>
+                              handleInputChange(
+                                "education",
+                                index,
+                                "institute",
+                                e.target.value
+                              )
+                            }
+                            required
+                            disabled={isSubmitted}
+                          />
+                        </div>
+
+                        <div>
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            CGPA/Percentage*
+                          </label>
+                          <input
+                            type="text"
+                            placeholder="e.g. 8.5 CGPA or 85\% (use \% for percentage or view instructions)"
+                            className={inputClasses}
+                            value={education.cgpa}
+                            onChange={(e) =>
+                              handleInputChange(
+                                "education",
+                                index,
+                                "cgpa",
+                                e.target.value
+                              )
+                            }
+                            required
+                            disabled={isSubmitted}
+                          />
+                        </div>
+
+                        <div>
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Year*
+                          </label>
+                          <input
+                            type="text"
+                            placeholder="e.g. 2020-2024"
+                            className={inputClasses}
+                            value={education.year}
+                            onChange={(e) =>
+                              handleInputChange(
+                                "education",
+                                index,
+                                "year",
+                                e.target.value
+                              )
+                            }
+                            required
+                            disabled={isSubmitted}
+                          />
+                        </div>
+                      </div>
+                      <div className="flex justify-end">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setDeleteTarget({ section: "education", index });
+                            setIsModalOpen(true);
+                          }}
+                          className=" text-red-500 hover:text-red-700 transition"
+                          disabled={isSubmitted}
+                          title="Delete this education entry"
+                        >
+                          <TrashIcon className="w-5 h-5" />
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </section>
+              )}
+              {sectionId === "experience" && (
+                <section className="mb-8">
+                  <div className="flex items-center justify-between mb-4">
+                    <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
+                      <span className="mr-2"></span> Experience
+                    </h2>
+                    <button
+                      type="button"
+                      onClick={() => addEntry("experience")}
+                      className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
+                      disabled={isSubmitted}
+                    >
+                      <PlusIcon className="w-5 h-5 mr-1" />
+                      Add Experience
+                    </button>
+                  </div>
+
+                  {(resumeData.experience || []).map((experience, index) => (
+                    <div key={index} className={sectionCardClasses}>
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                        <div>
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Company*
+                          </label>
+                          <input
+                            type="text"
+                            placeholder="Company name"
+                            className={inputClasses}
+                            value={experience.company}
+                            onChange={(e) =>
+                              handleInputChange(
+                                "experience",
+                                index,
+                                "company",
+                                e.target.value
+                              )
+                            }
+                            required
+                            disabled={isSubmitted}
+                          />
+                        </div>
+
+                        <div>
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Location
+                          </label>
+                          <input
+                            type="text"
+                            placeholder="e.g. Remote, Bangalore, etc."
+                            className={inputClasses}
+                            value={experience.location}
+                            onChange={(e) =>
+                              handleInputChange(
+                                "experience",
+                                index,
+                                "location",
+                                e.target.value
+                              )
+                            }
+                            disabled={isSubmitted}
+                            required
+                          />
+                        </div>
+
+                        <div>
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Role*
+                          </label>
+                          <input
+                            type="text"
+                            placeholder="Your position"
+                            className={inputClasses}
+                            value={experience.role}
+                            onChange={(e) =>
+                              handleInputChange(
+                                "experience",
+                                index,
+                                "role",
+                                e.target.value
+                              )
+                            }
+                            required
+                            disabled={isSubmitted}
+                          />
+                        </div>
+
+                        <div>
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Timeline*
+                          </label>
+                          <input
+                            type="text"
+                            placeholder="e.g. June 2022 - Present"
+                            className={inputClasses}
+                            value={experience.timeline}
+                            onChange={(e) =>
+                              handleInputChange(
+                                "experience",
+                                index,
+                                "timeline",
+                                e.target.value
+                              )
+                            }
+                            required
+                            disabled={isSubmitted}
+                          />
+                        </div>
+                      </div>
+
+                      <div className="mt-4">
+                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                          Work Done
+                        </label>
+                        {experience.workDone &&
+                          (experience.workDone || []).map((task, taskIndex) => (
+                            <div
+                              key={taskIndex}
+                              className="flex items-center gap-2 mb-2"
+                            >
+                              <span className="text-gray-500 dark:text-gray-400">
+                                •
+                              </span>
+                              <input
+                                type="text"
+                                placeholder={`Describe your work (${
+                                  taskIndex + 1
+                                })`}
+                                className={`${inputClasses} flex-1`}
+                                value={task}
+                                onChange={(e) => {
+                                  const updatedData = { ...resumeData };
+                                  updatedData.experience[index].workDone[
+                                    taskIndex
+                                  ] = e.target.value;
+                                  setResumeData(updatedData);
+                                }}
+                                disabled={isSubmitted}
+                              />
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  const updatedData = { ...resumeData };
+                                  updatedData.experience[index].workDone.splice(
+                                    taskIndex,
+                                    1
+                                  );
+                                  setResumeData(updatedData);
+                                }}
+                                className="text-red-500 hover:text-red-700 p-2 rounded-full hover:bg-red-50 dark:hover:bg-gray-700 transition"
+                                title="Delete this task"
+                                disabled={isSubmitted}
+                              >
+                                <TrashIcon className="w-4 h-4" />
+                              </button>
+                            </div>
+                          ))}
+                        <button
+                          type="button"
+                          onClick={() => addWorkDone("experience", index)}
+                          className={`${buttonClasses} mt-2 bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 text-sm`}
+                          disabled={isSubmitted}
+                        >
+                          + Add Work Description
+                        </button>
+                      </div>
+
+                      <div className="flex justify-end">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setDeleteTarget({ section: "experience", index });
+                            setIsModalOpen(true);
+                          }}
+                          className=" text-red-500 hover:text-red-700 transition"
+                          disabled={isSubmitted}
+                          title="Delete this experience entry"
+                        >
+                          <TrashIcon className="w-5 h-5" />
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </section>
+              )}
+              {sectionId === "projects" && (
+                <section className="mb-8">
+                  <div className="flex items-center justify-between mb-4">
+                    <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
+                      <span className="mr-2"></span> Projects
+                    </h2>
+                    <button
+                      type="button"
+                      onClick={() => addEntry("projects")}
+                      className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
+                      disabled={isSubmitted}
+                    >
+                      <PlusIcon className="w-5 h-5 mr-1" />
+                      Add Project
+                    </button>
+                  </div>
+
+                  {(resumeData.projects || []).map((project, index) => (
+                    <div key={index} className={sectionCardClasses}>
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                        <div>
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Project Name*
+                          </label>
+                          <input
+                            type="text"
+                            placeholder="Project title"
+                            className={inputClasses}
+                            value={project.name}
+                            onChange={(e) =>
+                              handleInputChange(
+                                "projects",
+                                index,
+                                "name",
+                                e.target.value
+                              )
+                            }
+                            required
+                            disabled={isSubmitted}
+                          />
+                        </div>
+
+                        <div>
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Project Type
+                          </label>
+                          <input
+                            type="text"
+                            placeholder="e.g. Web App, Research, etc."
+                            className={inputClasses}
+                            value={project.type}
+                            onChange={(e) =>
+                              handleInputChange(
+                                "projects",
+                                index,
+                                "type",
+                                e.target.value
+                              )
+                            }
+                            disabled={isSubmitted}
+                          />
+                        </div>
+
+                        <div>
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Timeline
+                          </label>
+                          <input
+                            type="text"
+                            placeholder="e.g. Jan 2023 - May 2023"
+                            className={inputClasses}
+                            value={project.timeline}
+                            onChange={(e) =>
+                              handleInputChange(
+                                "projects",
+                                index,
+                                "timeline",
+                                e.target.value
+                              )
+                            }
+                            disabled={isSubmitted}
+                          />
+                        </div>
+
+                        <div>
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            GitHub Link
+                          </label>
+                          <input
+                            type="url"
+                            placeholder="Project repository URL"
+                            className={inputClasses}
+                            value={project.githubLink}
+                            onChange={(e) =>
+                              handleInputChange(
+                                "projects",
+                                index,
+                                "githubLink",
+                                e.target.value
+                              )
+                            }
+                            disabled={isSubmitted}
+                          />
+                        </div>
+                      </div>
+
+                      <div className="mt-4">
+                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                          Project Details
+                        </label>
+                        {project.workDone &&
+                          (project.workDone || []).map((task, taskIndex) => (
+                            <div
+                              key={taskIndex}
+                              className="flex items-center gap-2 mb-2"
+                            >
+                              <span className="text-gray-500 dark:text-gray-400">
+                                •
+                              </span>
+                              <input
+                                type="text"
+                                placeholder={`Project detail (${
+                                  taskIndex + 1
+                                })`}
+                                className={`${inputClasses} flex-1`}
+                                value={task}
+                                onChange={(e) => {
+                                  const updatedData = { ...resumeData };
+                                  updatedData.projects[index].workDone[
+                                    taskIndex
+                                  ] = e.target.value;
+                                  setResumeData(updatedData);
+                                }}
+                                disabled={isSubmitted}
+                              />
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  const updatedData = { ...resumeData };
+                                  updatedData.projects[index].workDone.splice(
+                                    taskIndex,
+                                    1
+                                  );
+                                  setResumeData(updatedData);
+                                }}
+                                className="text-red-500 hover:text-red-700 p-2 rounded-full hover:bg-red-50 dark:hover:bg-gray-700 transition"
+                                title="Delete this detail"
+                                disabled={isSubmitted}
+                              >
+                                <TrashIcon className="w-4 h-4" />
+                              </button>
+                            </div>
+                          ))}
+                        <button
+                          type="button"
+                          onClick={() => {
+                            const updatedData = { ...resumeData };
+
+                            if (!updatedData.projects) {
+                              updatedData.projects = [];
+                            }
+                            if (!updatedData.projects[index]) {
+                              updatedData.projects[index] = {};
+                            }
+
+                            if (
+                              !Array.isArray(
+                                updatedData.projects[index].workDone
+                              )
+                            ) {
+                              updatedData.projects[index].workDone = [];
+                            }
+
+                            updatedData.projects[index].workDone.push("");
+                            setResumeData(updatedData);
+                          }}
+                          className={`${buttonClasses} mt-2 bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 text-sm`}
+                          disabled={isSubmitted}
+                        >
+                          + Add Project Detail
+                        </button>
+                      </div>
+                      <div className="flex justify-end">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setDeleteTarget({ section: "projects", index });
+                            setIsModalOpen(true);
+                          }}
+                          className=" text-red-500 hover:text-red-700 transition"
+                          disabled={isSubmitted}
+                          title="Delete this project"
+                        >
+                          <TrashIcon className="w-5 h-5" />
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </section>
+              )}
+              {sectionId === "skills" && (
+                <section className="mb-8">
+                  <div className="flex items-center justify-between mb-4">
+                    <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
+                      <span className="mr-2"></span> Technical Skills
+                    </h2>
+                    <button
+                      type="button"
+                      onClick={() => addEntry("technicalSkills")}
+                      className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
+                      disabled={isSubmitted}
+                    >
+                      <PlusIcon className="w-5 h-5 mr-1" />
+                      Add Skill
+                    </button>
+                  </div>
+
+                  {(resumeData.technicalSkills || []).map((skill, index) => (
+                    <div key={index} className={sectionCardClasses}>
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Category*
+                          </label>
+                          <input
+                            type="text"
+                            placeholder="e.g. Programming Languages, Tools, etc."
+                            className={inputClasses}
+                            value={skill.category}
+                            onChange={(e) =>
+                              handleInputChange(
+                                "technicalSkills",
+                                index,
+                                "category",
+                                e.target.value
+                              )
+                            }
+                            required
+                            disabled={isSubmitted}
+                          />
+                        </div>
+
+                        <div>
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Skills*
+                          </label>
+                          <input
+                            type="text"
+                            placeholder="Comma separated list (e.g. Java, Python, C++)"
+                            className={inputClasses}
+                            value={skill.skills}
+                            onChange={(e) =>
+                              handleInputChange(
+                                "technicalSkills",
+                                index,
+                                "skills",
+                                e.target.value
+                              )
+                            }
+                            required
+                            disabled={isSubmitted}
+                          />
+                        </div>
+                      </div>
+                      <div className="flex justify-end pt-2">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setDeleteTarget({
+                              section: "technicalSkills",
+                              index,
+                            });
+                            setIsModalOpen(true);
+                          }}
+                          className=" text-red-500 hover:text-red-700 transition"
+                          disabled={isSubmitted}
+                          title="Delete this skill category"
+                        >
+                          <TrashIcon className="w-5 h-5" />
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </section>
+              )}
+              {sectionId === "courses" && (
+                <section className="mb-8">
+                  <div className="flex items-center justify-between mb-4">
+                    <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
+                      <span className="mr-2"></span> Key Courses Taken
+                    </h2>
+                    <button
+                      type="button"
+                      onClick={() => addEntry("courses")}
+                      className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
+                      disabled={isSubmitted}
+                    >
+                      <PlusIcon className="w-5 h-5 mr-1" />
+                      Add Course
+                    </button>
+                  </div>
+
+                  {(resumeData.courses || []).map((course, index) => (
+                    <div key={index} className={sectionCardClasses}>
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Category
+                          </label>
+                          <input
+                            type="text"
+                            placeholder="e.g. Core, Electives, etc."
+                            className={inputClasses}
+                            value={course.category}
+                            onChange={(e) =>
+                              handleInputChange(
+                                "courses",
+                                index,
+                                "category",
+                                e.target.value
+                              )
+                            }
+                            disabled={isSubmitted}
+                          />
+                        </div>
+
+                        <div>
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Course Name*
+                          </label>
+                          <input
+                            type="text"
+                            placeholder="Course title"
+                            className={inputClasses}
+                            value={course.courseName}
+                            onChange={(e) =>
+                              handleInputChange(
+                                "courses",
+                                index,
+                                "courseName",
+                                e.target.value
+                              )
+                            }
+                            required
+                            disabled={isSubmitted}
+                          />
+                        </div>
+                      </div>
+                      <div className="flex justify-end pt-2">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setDeleteTarget({ section: "courses", index });
+                            setIsModalOpen(true);
+                          }}
+                          className=" text-red-500 hover:text-red-700 transition"
+                          disabled={isSubmitted}
+                          title="Delete this course"
+                        >
+                          <TrashIcon className="w-5 h-5" />
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </section>
+              )}
+              {sectionId === "pors" && (
+                <section className="mb-8">
+                  <div className="flex items-center justify-between mb-4">
+                    <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
+                      <span className="mr-2"></span> Positions of Responsibility
+                    </h2>
+                    <button
+                      type="button"
+                      onClick={() => addEntry("positions")}
+                      className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
+                      disabled={isSubmitted}
+                    >
+                      <PlusIcon className="w-5 h-5 mr-1" />
+                      Add Position
+                    </button>
+                  </div>
+
+                  {(resumeData.positions || []).map((position, index) => (
+                    <div key={index} className={sectionCardClasses}>
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                        <div>
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Position Title*
+                          </label>
+                          <input
+                            type="text"
+                            placeholder="e.g. President, Secretary, etc."
+                            className={inputClasses}
+                            value={position.title}
+                            onChange={(e) =>
+                              handleInputChange(
+                                "positions",
+                                index,
+                                "title",
+                                e.target.value
+                              )
+                            }
+                            required
+                            disabled={isSubmitted}
+                          />
+                        </div>
+
+                        <div>
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Organization*
+                          </label>
+                          <input
+                            type="text"
+                            placeholder="Organization name"
+                            className={inputClasses}
+                            value={position.organization}
+                            onChange={(e) =>
+                              handleInputChange(
+                                "positions",
+                                index,
+                                "organization",
+                                e.target.value
+                              )
+                            }
+                            required
+                            disabled={isSubmitted}
+                          />
+                        </div>
+
+                        <div>
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Timeline
+                          </label>
+                          <input
+                            type="text"
+                            placeholder="e.g. 2022-2023"
+                            className={inputClasses}
+                            value={position.timeline}
+                            onChange={(e) =>
+                              handleInputChange(
+                                "positions",
+                                index,
+                                "timeline",
+                                e.target.value
+                              )
+                            }
+                            disabled={isSubmitted}
+                          />
+                        </div>
+                      </div>
+
+                      <div className="mt-4">
+                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                          Description
+                        </label>
+                        {position.description &&
+                          (position.description || []).map(
+                            (desc, descIndex) => (
+                              <div
+                                key={descIndex}
+                                className="flex items-center gap-2 mb-2"
+                              >
+                                <span className="text-gray-500 dark:text-gray-400">
+                                  •
+                                </span>
+                                <input
+                                  type="text"
+                                  placeholder={`Responsibility detail (${
+                                    descIndex + 1
+                                  })`}
+                                  className={`${inputClasses} flex-1`}
+                                  value={desc}
+                                  onChange={(e) => {
+                                    const updatedData = { ...resumeData };
+                                    updatedData.positions[index].description[
+                                      descIndex
+                                    ] = e.target.value;
+                                    setResumeData(updatedData);
+                                  }}
+                                  disabled={isSubmitted}
+                                />
+                                <button
+                                  type="button"
+                                  onClick={() => {
+                                    const updatedData = { ...resumeData };
+                                    updatedData.positions[
+                                      index
+                                    ].description.splice(descIndex, 1);
+                                    setResumeData(updatedData);
+                                  }}
+                                  className="text-red-500 hover:text-red-700 p-2 rounded-full hover:bg-red-50 dark:hover:bg-gray-700 transition"
+                                  title="Delete this description"
+                                  disabled={isSubmitted}
+                                >
+                                  <TrashIcon className="w-4 h-4" />
+                                </button>
+                              </div>
+                            )
+                          )}
+                        <button
+                          type="button"
+                          onClick={() => {
+                            const updatedData = { ...resumeData };
+
+                            if (!updatedData.positions) {
+                              updatedData.positions = [];
+                            }
+
+                            if (!updatedData.positions[index]) {
+                              updatedData.positions[index] = {
+                                description: [],
+                              };
+                            }
+
+                            if (
+                              !Array.isArray(
+                                updatedData.positions[index].description
+                              )
+                            ) {
+                              updatedData.positions[index].description = [];
+                            }
+
+                            updatedData.positions[index].description.push("");
+                            setResumeData(updatedData);
+                          }}
+                          className={`${buttonClasses} mt-2 bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 text-sm`}
+                          disabled={isSubmitted}
+                        >
+                          + Add Responsibility
+                        </button>
+                      </div>
+                      <div className="flex justify-end">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setDeleteTarget({ section: "positions", index });
+                            setIsModalOpen(true);
+                          }}
+                          className=" text-red-500 hover:text-red-700 transition"
+                          disabled={isSubmitted}
+                          title="Delete this position"
+                        >
+                          <TrashIcon className="w-5 h-5" />
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </section>
+              )}
+              {sectionId === "extracaurriculars" && (
+                <section className="mb-8">
+                  <div className="flex items-center justify-between mb-4">
+                    <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
+                      <span className="mr-2"></span> Extra-curriculars
+                    </h2>
+                    <button
+                      type="button"
+                      onClick={() => addEntry("extracaurriculars")}
+                      className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
+                      disabled={isSubmitted}
+                    >
+                      <PlusIcon className="w-5 h-5 mr-1" />
+                      Add Activity
+                    </button>
+                  </div>
+
+                  {(resumeData.extracaurriculars || []).map(
+                    (activity, index) => (
+                      <div key={index} className={sectionCardClasses}>
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                          <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                              Title*
+                            </label>
+                            <input
+                              type="text"
+                              placeholder="Activity title"
+                              className={inputClasses}
+                              value={activity.title}
+                              onChange={(e) =>
+                                handleInputChange(
+                                  "extracaurriculars",
+                                  index,
+                                  "title",
+                                  e.target.value
+                                )
+                              }
+                              required
+                              disabled={isSubmitted}
+                            />
+                          </div>
+
+                          <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                              Organization
+                            </label>
+                            <input
+                              type="text"
+                              placeholder="Organization name"
+                              className={inputClasses}
+                              value={activity.organization}
+                              onChange={(e) =>
+                                handleInputChange(
+                                  "extracaurriculars",
+                                  index,
+                                  "organization",
+                                  e.target.value
+                                )
+                              }
+                              disabled={isSubmitted}
+                            />
+                          </div>
+
+                          <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                              Timeline
+                            </label>
+                            <input
+                              type="text"
+                              placeholder="e.g. 2021-2022"
+                              className={inputClasses}
+                              value={activity.timeline}
+                              onChange={(e) =>
+                                handleInputChange(
+                                  "extracaurriculars",
+                                  index,
+                                  "timeline",
+                                  e.target.value
+                                )
+                              }
+                              disabled={isSubmitted}
+                            />
+                          </div>
+                        </div>
+
+                        <div className="mt-4">
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                            Description
+                          </label>
+                          {activity.description &&
+                            (activity.description || []).map(
+                              (desc, descIndex) => (
+                                <div
+                                  key={descIndex}
+                                  className="flex items-center gap-2 mb-2"
+                                >
+                                  <span className="text-gray-500 dark:text-gray-400">
+                                    •
+                                  </span>
+                                  <input
+                                    type="text"
+                                    placeholder={`Activity detail (${
+                                      descIndex + 1
+                                    })`}
+                                    className={`${inputClasses} flex-1`}
+                                    value={desc}
+                                    onChange={(e) => {
+                                      const updatedData = { ...resumeData };
+                                      updatedData.extracaurriculars[
+                                        index
+                                      ].description[descIndex] = e.target.value;
+                                      setResumeData(updatedData);
+                                    }}
+                                    disabled={isSubmitted}
+                                  />
+                                  <button
+                                    type="button"
+                                    onClick={() => {
+                                      const updatedData = { ...resumeData };
+                                      updatedData.extracaurriculars[
+                                        index
+                                      ].description.splice(descIndex, 1);
+                                      setResumeData(updatedData);
+                                    }}
+                                    className="text-red-500 hover:text-red-700 p-2 rounded-full hover:bg-red-50 dark:hover:bg-gray-700 transition"
+                                    title="Delete this description"
+                                    disabled={isSubmitted}
+                                  >
+                                    <TrashIcon className="w-4 h-4" />
+                                  </button>
+                                </div>
+                              )
+                            )}
+                          <button
+                            type="button"
+                            onClick={() => {
+                              const updatedData = { ...resumeData };
+
+                              if (!updatedData.extracaurriculars) {
+                                updatedData.extracaurriculars = [];
+                              }
+
+                              if (!updatedData.extracaurriculars[index]) {
+                                updatedData.extracaurriculars[index] = {
+                                  description: [],
+                                };
+                              }
+
+                              if (
+                                !Array.isArray(
+                                  updatedData.extracaurriculars[index]
+                                    .description
+                                )
+                              ) {
+                                updatedData.extracaurriculars[
+                                  index
+                                ].description = [];
+                              }
+
+                              updatedData.extracaurriculars[
+                                index
+                              ].description.push("");
+                              setResumeData(updatedData);
+                            }}
+                            className={`${buttonClasses} mt-2 bg-gray-100 text-gray-800 hover:bg-gray-200 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 text-sm`}
+                            disabled={isSubmitted}
+                          >
+                            + Add Description
+                          </button>
+                        </div>
+                        <div className="flex justify-end">
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setDeleteTarget({
+                                section: "extracaurriculars",
+                                index,
+                              });
+                              setIsModalOpen(true);
+                            }}
+                            className="text-red-500 hover:text-red-700 transition"
+                            disabled={isSubmitted}
+                            title="Delete this activity"
+                          >
+                            <TrashIcon className="w-5 h-5" />
+                          </button>
+                        </div>
+                      </div>
+                    )
+                  )}
+                </section>
+              )}
+              {sectionId === "achievements" && (
+                <section className="mb-8">
+                  <div className="flex items-center justify-between mb-4">
+                    <h2 className="text-2xl font-bold text-gray-800 dark:text-white flex items-center">
+                      <span className="mr-2"></span> Achievements
+                    </h2>
+                    <button
+                      type="button"
+                      onClick={() => addEntry("achievements")}
+                      className={`${buttonClasses} bg-blue-100 text-blue-800 hover:bg-blue-200 dark:bg-blue-900 dark:text-white dark:hover:bg-blue-800 flex items-center`}
+                      disabled={isSubmitted}
+                    >
+                      <PlusIcon className="w-5 h-5 mr-1" />
+                      Add Achievement
+                    </button>
+                  </div>
+
+                  {(resumeData.achievements || []).map((achievement, index) => (
+                    <div key={index} className={sectionCardClasses}>
+                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Achievement Title*
+                          </label>
+                          <input
+                            type="text"
+                            placeholder="e.g. First Place in Hackathon"
+                            className={inputClasses}
+                            value={achievement.title || ""}
+                            onChange={(e) =>
+                              handleInputChange(
+                                "achievements",
+                                index,
+                                "title",
+                                e.target.value
+                              )
+                            }
+                            required
+                            disabled={isSubmitted}
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Description
+                          </label>
+                          <input
+                            type="text"
+                            placeholder="e.g. Developed a web app in 24 hours"
+                            className={inputClasses}
+                            value={achievement.description || ""}
+                            onChange={(e) =>
+                              handleInputChange(
+                                "achievements",
+                                index,
+                                "description",
+                                e.target.value
+                              )
+                            }
+                            disabled={isSubmitted}
+                          />
+                        </div>
+                        <div>
+                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Year
+                          </label>
+                          <input
+                            type="text"
+                            placeholder="e.g. 2023"
+                            className={inputClasses}
+                            value={achievement.year || ""}
+                            onChange={(e) =>
+                              handleInputChange(
+                                "achievements",
+                                index,
+                                "year",
+                                e.target.value
+                              )
+                            }
+                            disabled={isSubmitted}
+                          />
+                        </div>
+                      </div>
+                      <div className="flex justify-end">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setDeleteTarget({ section: "achievements", index });
+                            setIsModalOpen(true);
+                          }}
+                          className=" text-red-500 hover:text-red-700 transition"
+                          disabled={isSubmitted}
+                          title="Delete this achievement"
+                        >
+                          <TrashIcon className="w-5 h-5" />
+                        </button>
+                      </div>
+                    </div>
+                  ))}
+                </section>
+              )}
+            </DraggableSection>
+          ))}
+        </SortableContext>
+
+        {/* Submit Button */}
+        <div className="flex justify-end mt-8">
+          <button
+            type="submit"
+            className={`${buttonClasses} bg-blue-600 text-white hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-600 flex items-center space-x-2`}
+            disabled={isSubmitted}
+            // onClick={handleSubmit}
+          >
+            {isSubmitted ? (
+              <>
+                <svg
+                  className="animate-spin h-5 w-5 text-white"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  ></circle>
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  ></path>
+                </svg>
+                <span>Generating...</span>
+              </>
+            ) : (
+              <span>Generate Resume</span>
+            )}
+          </button>
+        </div>
+      </form>
+      <Footer darkMode={darkMode}></Footer>
+    </>
+  );
 };
 
 export default ResumeBuilder;

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -9,6 +9,7 @@ export function useAuth() {
   useEffect(() => {
     axios.get(`${process.env.REACT_APP_SERVER_URL}/api/user`, { withCredentials: true })
       .then(res => {
+         setLoading(true);
         if (res.data.authenticated) {
           setUser(res.data.user);
           setAuthenticated(true);

--- a/src/pages/ResumeBuilderPage.js
+++ b/src/pages/ResumeBuilderPage.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from "react-router-dom";
 import ResumeBuilder from "../Components/ResumeBuilder.js";
 import DisplayResume from "../Components/DisplayResume.js";
 import Instructions from "../Components/Instructions.js";
@@ -8,235 +8,285 @@ import { ChevronRightIcon, ChevronLeftIcon } from "@heroicons/react/24/outline";
 import LatexCode from "../Components/LatexCode.js";
 import { useLatex } from "../Components/LatexContext.js";
 import axios from "axios";
+import { DndContext, closestCorners, KeyboardSensor, PointerSensor, useSensor, useSensors, TouchSensor } from '@dnd-kit/core';
+import { arrayMove, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 
 function ResumeBuilderPage({ apiUser }) {
-    const [user, setUser] = useState(null);
-    useEffect(() => {
-        setUser(apiUser);
-    }, [apiUser]);
+  const [user, setUser] = useState(null);
+  useEffect(() => {
+    setUser(apiUser);
+  }, [apiUser]);
 
-    const [instructions, setInstructions] = useState(false);
-    const [showPreview, setShowPreview] = useState(false);
-    const [errors, setErrors] = useState({});
-    const [darkMode, setDarkMode] = useState(false);
-    const navigate = useNavigate();
+  const [instructions, setInstructions] = useState(false);
+  const [showPreview, setShowPreview] = useState(false);
+  const [errors, setErrors] = useState({});
+  const [darkMode, setDarkMode] = useState(false);
+  const [sectionOrder, setSectionOrder] = useState([
+    "education",
+    "experience",
+    "projects",
+    "skills",
+    "courses",
+    "pors",
+    "extracaurriculars",
+    "achievements",
+  ]);
+  const navigate = useNavigate();
 
+  const sensors = useSensors(
+  useSensor(PointerSensor),
+  useSensor(TouchSensor),
+  useSensor(KeyboardSensor, {
+    coordinateGetter: sortableKeyboardCoordinates,
+  })
+);
 
-    // Dark mode toggle effect
-    useEffect(() => {
-        const html = document.documentElement;
-        if (darkMode) {
-            html.classList.add("dark");
-        } else {
-            html.classList.remove("dark");
-        }
-    }, [darkMode]);
+  // Dark mode toggle effect
+  useEffect(() => {
+    const html = document.documentElement;
+    if (darkMode) {
+      html.classList.add("dark");
+    } else {
+      html.classList.remove("dark");
+    }
+  }, [darkMode]);
 
-    const { latexCodeE, setLatexCode } = useLatex();
+  const { latexCodeE, setLatexCode } = useLatex();
 
-    // Templates for new entries
-    const entryTemplates = {
-        education: {
-            degree: "",
-            institute: "",
-            cgpa: "",
-            year: "",
-        },
-        experience: {
-            company: "",
-            location: "",
-            role: "",
-            timeline: "",
-            workDone: [],
-        },
-        projects: {
-            name: "",
-            type: "",
-            timeline: "",
-            githubLink: "",
-            workDone: [],
-        },
-        technicalSkills: {
-            category: "",
-            skills: "",
-        },
-        courses: {
-            category: "",
-            courseName: "",
-        },
-        positions: {
-            title: "",
-            organization: "",
-            timeline: "",
-            description: [],
-        },
-        extracaurriculars: {
-            title: "",
-            organization: "",
-            timeline: "",
-            description: [],
-        },
-        achievements: {
-            title: "",
-            description: "",
-            year: "",
-        },
+  // Templates for new entries
+  const entryTemplates = {
+    education: {
+      degree: "",
+      institute: "",
+      cgpa: "",
+      year: "",
+    },
+    experience: {
+      company: "",
+      location: "",
+      role: "",
+      timeline: "",
+      workDone: [],
+    },
+    projects: {
+      name: "",
+      type: "",
+      timeline: "",
+      githubLink: "",
+      workDone: [],
+    },
+    technicalSkills: {
+      category: "",
+      skills: "",
+    },
+    courses: {
+      category: "",
+      courseName: "",
+    },
+    positions: {
+      title: "",
+      organization: "",
+      timeline: "",
+      description: [],
+    },
+    extracaurriculars: {
+      title: "",
+      organization: "",
+      timeline: "",
+      description: [],
+    },
+    achievements: {
+      title: "",
+      description: "",
+      year: "",
+    },
+  };
+
+  // Initial state for resume data
+  const [resumeData, setResumeData] = useState({
+    fontSize: 11,
+    personalInfo: {
+      name: "",
+      rollNumber: "",
+      courseBranch: "",
+      contactNumber: "",
+      email: "",
+      githubProfile: "",
+      linkedinProfile: "",
+      secondaryEmail: "",
+      website: "",
+    },
+    education: [
+      {
+        degree: "",
+        institute: "",
+      },
+    ],
+    experience: [],
+    projects: [],
+    technicalSkills: [],
+    courses: [],
+    positions: [],
+    achievements: [],
+    extracaurriculars: [],
+  });
+
+  // Update resumeData from fetched user
+  useEffect(() => {
+    if (!user) return;
+
+    const {
+      fontSize,
+      personalInfo = {},
+      education = [],
+      experience = [],
+      projects = [],
+      technicalSkills = [],
+      courses = [],
+      positions = [],
+      achievements = [],
+      extracaurriculars = [],
+    } = user;
+
+    const newResumeData = {
+      fontSize: fontSize,
+      personalInfo: {
+        name: personalInfo.name || "",
+        rollNumber: personalInfo.rollNumber || "",
+        courseBranch: personalInfo.courseBranch || "",
+        contactNumber: personalInfo.contactNumber || "",
+        email: personalInfo.email || "",
+        githubProfile: personalInfo.githubProfile || "",
+        linkedinProfile: personalInfo.linkedinProfile || "",
+        secondaryEmail: personalInfo.secondaryEmail || "",
+        website: personalInfo.website || "",
+      },
     };
 
-    // Initial state for resume data
-    const [resumeData, setResumeData] = useState({
-        fontSize: 11,
-        personalInfo: {
-            name: "",
-            rollNumber: "",
-            courseBranch: "",
-            contactNumber: "",
-            email: "",
-            githubProfile: "",
-            linkedinProfile: "",
-            secondaryEmail: "",
-            website: "",
-        },
-        education: [
-            {
-                degree: "",
-                institute: "",
-            },
-        ],
-        experience: [],
-        projects: [],
-        technicalSkills: [],
-        courses: [],
-        positions: [],
-        achievements: [],
-        extracaurriculars: [],
+    if (education.length > 0) newResumeData.education = education;
+    if (experience.length > 0) newResumeData.experience = experience;
+    if (projects.length > 0) newResumeData.projects = projects;
+    if (technicalSkills.length > 0)
+      newResumeData.technicalSkills = technicalSkills;
+    if (courses.length > 0) newResumeData.courses = courses;
+    if (positions.length > 0) newResumeData.positions = positions;
+    if (achievements.length > 0) newResumeData.achievements = achievements;
+    if (extracaurriculars.length > 0)
+      newResumeData.extracaurriculars = extracaurriculars;
+
+    setResumeData(newResumeData);
+  }, [user]);
+
+  const handleDragEnd = (event) => {
+    const { active, over } = event;
+    if (active.id === over.id) return;
+    if (active.id !== over.id) {
+    setSectionOrder((items) => {
+      const oldIndex = items.indexOf(active.id);
+      const newIndex = items.indexOf(over.id);
+      
+      return arrayMove(items, oldIndex, newIndex);
     });
+  }
+  };
 
-    // Update resumeData from fetched user
-    useEffect(() => {
-        if (!user) return;
+  // Generate LaTeX code from resumeData
+  const latexCode = LatexCode({ resumeData });
 
-        const {
-            fontSize,
-            personalInfo = {},
-            education = [],
-            experience = [],
-            projects = [],
-            technicalSkills = [],
-            courses = [],
-            positions = [],
-            achievements = [],
-            extracaurriculars = [],
-        } = user;
+  //   if (loading || !authenticated) {
+  //     return <div className="h-screen w-screen bg-white dark:bg-gray-900" />;
+  //   }
 
-        const newResumeData = {
-            fontSize: fontSize,
-            personalInfo: {
-                name: personalInfo.name || "",
-                rollNumber: personalInfo.rollNumber || "",
-                courseBranch: personalInfo.courseBranch || "",
-                contactNumber: personalInfo.contactNumber || "",
-                email: personalInfo.email || "",
-                githubProfile: personalInfo.githubProfile || "",
-                linkedinProfile: personalInfo.linkedinProfile || "",
-                secondaryEmail: personalInfo.secondaryEmail || "",
-                website: personalInfo.website || "",
-            },
-        };
+  const handleLogout = async () => {
+    try {
+      await axios.get(`${process.env.REACT_APP_SERVER_URL}/auth/logout`, {
+        withCredentials: true,
+      });
+      setUser(null); // Clear user state
+      console.log("Logout successful clear user state");
+      navigate("/resume-builder/login"); // Navigate to landing page
+      navigate(0); // Refresh the page
+    } catch (err) {
+      console.error("Logout failed", err);
+    }
+  };
 
-        if (education.length > 0) newResumeData.education = education;
-        if (experience.length > 0) newResumeData.experience = experience;
-        if (projects.length > 0) newResumeData.projects = projects;
-        if (technicalSkills.length > 0) newResumeData.technicalSkills = technicalSkills;
-        if (courses.length > 0) newResumeData.courses = courses;
-        if (positions.length > 0) newResumeData.positions = positions;
-        if (achievements.length > 0) newResumeData.achievements = achievements;
-        if (extracaurriculars.length > 0) newResumeData.extracaurriculars = extracaurriculars;
+  return (
+    <div className="h-screen w-screen overflow-hidden bg-white dark:bg-gray-900 text-gray-800 dark:text-white transition">
+      {/* Navbar */}
+      <div className="fixed top-0 left-0 w-full z-50 bg-white shadow-md">
+        <Navbar
+          toogleDark={() => setDarkMode(!darkMode)}
+          darkMode={darkMode}
+          handleLogout={handleLogout}
+        />
+      </div>
 
-        setResumeData(newResumeData);
-    }, [user]);
-
-    // Generate LaTeX code from resumeData
-    const latexCode = LatexCode({ resumeData });
-
-    //   if (loading || !authenticated) {
-    //     return <div className="h-screen w-screen bg-white dark:bg-gray-900" />;
-    //   }
-
-    
-
-    const handleLogout = async () => {
-        try {
-            await axios.get(`${process.env.REACT_APP_SERVER_URL}/auth/logout`, {
-                withCredentials: true,
-            });
-            setUser(null); // Clear user state
-            console.log("Logout successful clear user state");
-            navigate('/resume-builder/login'); // Navigate to landing page
-            navigate(0); // Refresh the page
-        } catch (err) {
-            console.error("Logout failed", err);
-        }
-    };
-
-    return (
-        <div className="h-screen w-screen overflow-hidden bg-white dark:bg-gray-900 text-gray-800 dark:text-white transition">
-            {/* Navbar */}
-            <div className="fixed top-0 left-0 w-full z-50 bg-white shadow-md">
-                <Navbar toogleDark={() => setDarkMode(!darkMode)}
-                darkMode={darkMode}
-                handleLogout={handleLogout} />
-            </div>
-
-            {/* Main content */}
-            <div className="flex mt-16 h-[calc(100vh-4rem)] transition-all duration-700 ease-in-out">
-                {/* ResumeBuilder panel */}
-                <div
-                    className={`relative transition-all duration-700 ${showPreview ? "w-1/2" : "w-full"
-                        } h-full overflow-auto`}
-                >
-                    {/* Toggle preview button */}
-                    <div className="sticky top-0 z-10 flex justify-end pt-4">
-                        <button
-                            className="rounded text-gray-800 dark:text-white"
-                            onClick={() => setShowPreview(!showPreview)}
-                            aria-label={showPreview ? "Hide Preview" : "Show Preview"}
-                        >
-                            {showPreview ? (
-                                <ChevronRightIcon className="w-8 h-8 text-primary_text hover:text-hover_accent" />
-                            ) : (
-                                <ChevronLeftIcon className="w-8 h-8 text-primary_text hover:text-hover_accent" />
-                            )}
-                        </button>
-                    </div>
-
-                    <ResumeBuilder
-                        user={user}
-                        setUser={setUser}
-                        latexCode={latexCode}
-                        resumeData={resumeData}
-                        setResumeData={setResumeData}
-                        errors={errors}
-                        setErrors={setErrors}
-                        templates={entryTemplates}
-                        darkMode={darkMode}
-                    />
-                </div>
-
-                {/* Preview panel: either Instructions or DisplayResume */}
-                <div
-                    className={`transition-all duration-700 bg-gray-100 ${showPreview ? "w-1/2 translate-x-0" : "w-0 translate-x-full"
-                        } h-full overflow-y-auto bg-gray-100 dark:bg-gray-800`}
-                >
-                    {instructions ? (
-                        <Instructions setInstructions={setInstructions} resumeData={resumeData} latexCode={latexCode} />
-                    ) : (
-                        <DisplayResume setInstructions={setInstructions} resumeData={resumeData} latexCode={latexCode} />
-                    )}
-                </div>
-            </div>
+      {/* Main content */}
+      <div className="flex mt-16 h-[calc(100vh-4rem)] transition-all duration-700 ease-in-out">
+        {/* ResumeBuilder panel */}
+        <div
+          className={`relative transition-all duration-700 ${
+            showPreview ? "w-1/2" : "w-full"
+          } h-full overflow-auto`}
+        >
+          {/* Toggle preview button */}
+          <div className="sticky top-0 z-10 flex justify-end pt-4">
+            <button
+              className="rounded text-gray-800 dark:text-white"
+              onClick={() => setShowPreview(!showPreview)}
+              aria-label={showPreview ? "Hide Preview" : "Show Preview"}
+            >
+              {showPreview ? (
+                <ChevronRightIcon className="w-8 h-8 text-primary_text hover:text-hover_accent" />
+              ) : (
+                <ChevronLeftIcon className="w-8 h-8 text-primary_text hover:text-hover_accent" />
+              )}
+            </button>
+          </div>
+          <DndContext
+            sensors={sensors}
+            onDragEnd={handleDragEnd}
+            collisionDetection={closestCorners}
+          >
+            <ResumeBuilder
+              user={user}
+              setUser={setUser}
+              latexCode={latexCode}
+              resumeData={resumeData}
+              setResumeData={setResumeData}
+              errors={errors}
+              setErrors={setErrors}
+              templates={entryTemplates}
+              darkMode={darkMode}
+              sectionOrder={sectionOrder}
+            />
+          </DndContext>
         </div>
-    );
+
+        {/* Preview panel: either Instructions or DisplayResume */}
+        <div
+          className={`transition-all duration-700 bg-gray-100 ${
+            showPreview ? "w-1/2 translate-x-0" : "w-0 translate-x-full"
+          } h-full overflow-y-auto bg-gray-100 dark:bg-gray-800`}
+        >
+          {instructions ? (
+            <Instructions
+              setInstructions={setInstructions}
+              resumeData={resumeData}
+              latexCode={latexCode}
+            />
+          ) : (
+            <DisplayResume
+              setInstructions={setInstructions}
+              resumeData={resumeData}
+              latexCode={latexCode}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export default ResumeBuilderPage;

--- a/src/pages/ResumeBuilderPage.js
+++ b/src/pages/ResumeBuilderPage.js
@@ -25,9 +25,9 @@ function ResumeBuilderPage({ apiUser }) {
     "education",
     "experience",
     "projects",
-    "skills",
+    "technicalSkills",
     "courses",
-    "pors",
+    "positions",
     "extracaurriculars",
     "achievements",
   ]);
@@ -179,13 +179,13 @@ function ResumeBuilderPage({ apiUser }) {
 
   const handleDragEnd = (event) => {
     const { active, over } = event;
-    if (active.id === over.id) return;
-    if (active.id !== over.id) {
+    if (active?.id === over?.id) return;
+    if (active?.id !== over?.id) {
     setSectionOrder((items) => {
-      const oldIndex = items.indexOf(active.id);
-      const newIndex = items.indexOf(over.id);
-      
-      return arrayMove(items, oldIndex, newIndex);
+      const oldIndex = items.indexOf(active?.id);
+      const newIndex = items.indexOf(over?.id);
+      const newOrder = arrayMove(items, oldIndex, newIndex);
+      return newOrder;
     });
   }
   };


### PR DESCRIPTION
## **User description**
setup the drag-and-drop section ordering to resume builder.
Integrates dnd-kit for interactive rearrangement of resume sections, improving customization and user experience. Updates state logic to track section order and applies new drag event handling.
Fixes #31


___

## **CodeAnt-AI Description**
**Add drag-and-drop section reordering and autosave to Resume Builder**

### What Changed
- Resume sections in the builder can now be reordered by dragging a visible handle; drag-and-drop works with mouse, touch, and keyboard so users can rearrange Education, Experience, Projects, Skills, etc.
- The editor automatically saves changes to the server after a short pause (2s debounce) and includes a "Save Progress" button for an immediate manual save; saving shows a busy state and updates the signed-in user's data when successful.
- Each section is wrapped with a draggable handle and shows reduced opacity while dragging, and all section lists in the editor follow the new order immediately.

### Impact
`✅ Can reorder sections by drag-and-drop`
`✅ Auto-saves resume edits to server`
`✅ Keyboard and touch accessible section reordering`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
